### PR TITLE
Do not accelerate on Platform, Siding and Turn Back rail

### DIFF
--- a/src/main/java/mtr/data/Siding.java
+++ b/src/main/java/mtr/data/Siding.java
@@ -400,6 +400,7 @@ public class Siding extends SavedRailBase implements IPacket {
 		private static final float CONNECTION_HEIGHT = 2.25F;
 		private static final float CONNECTION_Z_OFFSET = 0.5F;
 		private static final float CONNECTION_X_OFFSET = 0.25F;
+		private boolean accelOnPlatform;
 
 		private Train(World world, long id, long sidingId, float railLength, List<PathData> path, List<Float> distances) {
 			super(id);
@@ -585,10 +586,19 @@ public class Siding extends SavedRailBase implements IPacket {
 							if (stoppingDistance < 0.5F * speed * speed / ACCELERATION) {
 								speed = Math.max(speed - (0.5F * speed * speed / stoppingDistance) * ticksElapsed, ACCELERATION);
 							} else {
-								final float railSpeed = path.get(getIndex(0, trainSpacing, false)).rail.railType.maxBlocksPerTick;
-								if (speed < railSpeed) {
+								final RailType rail = path.get(getIndex(0, trainSpacing, false)).rail.railType;
+								final float railSpeed = rail.maxBlocksPerTick;
+
+								if(speed < RailType.WOODEN.maxBlocksPerTick) {
+									accelOnPlatform = true;
+								} else if(speed == railSpeed) {
+									accelOnPlatform = false;
+								}
+
+								if (speed < railSpeed && ((rail != RailType.PLATFORM && rail != RailType.SIDING && rail != RailType.TURN_BACK) || accelOnPlatform)) {
 									speed = Math.min(speed + newAcceleration, railSpeed);
 								} else if (speed > railSpeed) {
+									accelOnPlatform = false;
 									speed = Math.max(speed - newAcceleration, railSpeed);
 								}
 							}


### PR DESCRIPTION
This is a minor PR that reverts the behavior on beta-6, where the train would hold it's speed when it's in a platform rail.

After this PR, trains will not accelerate when:

- The current section is Platform Rail, Siding Rail and Turn Back Rail.
- At least 20km/h is reached

If 20km/h (Speed limit for wooden rail) is not reached (Stopped right before the platform rail etc.) it will still accelerate until the speed limit no matter the rail.