### PR TITLE
Added Destination Filter to Schedule Sensor

### DIFF
--- a/src/main/java/mtr/block/BlockScheduleSensor.java
+++ b/src/main/java/mtr/block/BlockScheduleSensor.java
@@ -18,6 +18,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.Property;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Tickable;
@@ -138,16 +139,23 @@ public class BlockScheduleSensor extends Block implements BlockEntityProvider {
                 final Block block = serverworld.getBlockState(pos).getBlock();
 
                 if(Objects.equals(getDest(), "") || getDest() == null) {
-                    if(seconds <= Integer.parseInt(getOffSet()) && seconds > 0) {
+                    if(seconds <= Integer.parseInt(getOffSet())) {
                         serverworld.setBlockState(pos, serverworld.getBlockState(pos).with(BlockScheduleSensor.POWERED, true));
-                    } else if(seconds <= 0) {
-                        serverworld.getBlockTickScheduler().schedule(pos, block, 20);
+                    } else {
+                        Boolean isPowered = serverworld.getBlockState(pos).get(POWERED);
+                        if(isPowered) {
+                            serverworld.getBlockTickScheduler().schedule(pos, block, 20);
+                        }
+
                     }
                 } else {
-                    if(seconds <= Integer.parseInt(getOffSet()) && seconds > 0 && Objects.equals(destination, getDest())) {
+                    if(seconds <= Integer.parseInt(getOffSet()) && Objects.equals(destination, getDest())) {
                         serverworld.setBlockState(pos, serverworld.getBlockState(pos).with(BlockScheduleSensor.POWERED, true));
-                    } else if(seconds <= 0) {
-                        serverworld.getBlockTickScheduler().schedule(pos, block, 20);
+                    } else {
+                        Boolean isPowered = serverworld.getBlockState(pos).get(POWERED);
+                        if(isPowered) {
+                            serverworld.getBlockTickScheduler().schedule(pos, block, 20);
+                        }
                     }
                 }
 

--- a/src/main/java/mtr/block/BlockScheduleSensor.java
+++ b/src/main/java/mtr/block/BlockScheduleSensor.java
@@ -134,9 +134,6 @@ public class BlockScheduleSensor extends Block implements BlockEntityProvider {
                 seconds = (int) ((currentSchedule.arrivalMillis - System.currentTimeMillis()) / 1000);
                 destination = currentSchedule.destination;
 
-                System.out.println(destination);
-                System.out.println(getDest());
-
                 ServerWorld serverworld = (ServerWorld) world;
                 final Block block = serverworld.getBlockState(pos).getBlock();
 
@@ -146,14 +143,12 @@ public class BlockScheduleSensor extends Block implements BlockEntityProvider {
                     } else if(seconds <= 0) {
                         serverworld.getBlockTickScheduler().schedule(pos, block, 20);
                     }
-                    System.out.println("1");
                 } else {
                     if(seconds <= Integer.parseInt(getOffSet()) && seconds > 0 && Objects.equals(destination, getDest())) {
                         serverworld.setBlockState(pos, serverworld.getBlockState(pos).with(BlockScheduleSensor.POWERED, true));
                     } else if(seconds <= 0) {
                         serverworld.getBlockTickScheduler().schedule(pos, block, 20);
                     }
-                    System.out.println("2");
                 }
 
             }

--- a/src/main/java/mtr/gui/EditScheduleSensorScreen.java
+++ b/src/main/java/mtr/gui/EditScheduleSensorScreen.java
@@ -18,11 +18,15 @@ import net.minecraft.world.World;
 public class EditScheduleSensorScreen extends Screen implements IGui, IPacket {
 
     private final BlockPos pos;
-    private final String message;
+    private final String offset;
+    private final String dest;
     private final TextFieldWidget textFieldMessage;
-    private final Text text = new TranslatableText("gui.mtr.schedule_sensor_label");
+    private final TextFieldWidget textFieldMessage2;
 
-    private static final int MAX_MESSAGE_LENGTH = 256;
+    private final Text text = new TranslatableText("gui.mtr.schedule_sensor_label");
+    private final Text text2 = new TranslatableText("gui.mtr.schedule_sensor_label2");
+
+    private static final int MAX_MESSAGE_LENGTH = 64;
 
     public EditScheduleSensorScreen(BlockPos pos) {
         super(new LiteralText(""));
@@ -31,14 +35,16 @@ public class EditScheduleSensorScreen extends Screen implements IGui, IPacket {
 
         client = MinecraftClient.getInstance();
         textFieldMessage = new TextFieldWidget(client.textRenderer, 0, 0, 0, SQUARE_SIZE, new LiteralText(""));
-
+        textFieldMessage2 = new TextFieldWidget(client.textRenderer, 0, 0, 0, SQUARE_SIZE, new LiteralText(""));
 
         final World world = client.world;
         if (world != null) {
             final BlockEntity entity = world.getBlockEntity(pos);
-            message = entity instanceof BlockScheduleSensor.TileEntityBlockScheduleSensor ? ((BlockScheduleSensor.TileEntityBlockScheduleSensor ) entity).getMessage() : "";
+            offset = entity instanceof BlockScheduleSensor.TileEntityBlockScheduleSensor ? ((BlockScheduleSensor.TileEntityBlockScheduleSensor ) entity).getOffSet() : "";
+            dest = entity instanceof BlockScheduleSensor.TileEntityBlockScheduleSensor ? ((BlockScheduleSensor.TileEntityBlockScheduleSensor ) entity).getDest() : "";
         } else {
-            message = "";
+            offset = "";
+            dest = "";
         }
     }
 
@@ -46,20 +52,25 @@ public class EditScheduleSensorScreen extends Screen implements IGui, IPacket {
     protected void init() {
         super.init();
         IDrawing.setPositionAndWidth(textFieldMessage, SQUARE_SIZE + TEXT_FIELD_PADDING / 2, SQUARE_SIZE * 2 + TEXT_FIELD_PADDING / 2, width - SQUARE_SIZE * 2 - TEXT_FIELD_PADDING);
+        IDrawing.setPositionAndWidth(textFieldMessage2, SQUARE_SIZE + TEXT_FIELD_PADDING / 2, (SQUARE_SIZE * 2 + TEXT_FIELD_PADDING / 2) * 2, width - SQUARE_SIZE * 2 - TEXT_FIELD_PADDING);
         textFieldMessage.setMaxLength(MAX_MESSAGE_LENGTH);
-        textFieldMessage.setText(message);
+        textFieldMessage.setText(offset);
+        textFieldMessage2.setMaxLength(MAX_MESSAGE_LENGTH);
+        textFieldMessage2.setText(dest);
         addChild(textFieldMessage);
+        addChild(textFieldMessage2);
 
     }
 
     @Override
     public void tick() {
         textFieldMessage.tick();
+        textFieldMessage2.tick();
     }
 
     @Override
     public void onClose() {
-        PacketTrainDataGuiClient.sendScheduleSensorC2S(pos, textFieldMessage.getText());
+        PacketTrainDataGuiClient.sendScheduleSensorC2S(pos, textFieldMessage.getText(), textFieldMessage2.getText());
         super.onClose();
     }
 
@@ -67,8 +78,10 @@ public class EditScheduleSensorScreen extends Screen implements IGui, IPacket {
     public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
         try {
             renderBackground(matrices);
-            textRenderer.draw(matrices, text, SQUARE_SIZE + TEXT_PADDING, SQUARE_SIZE + TEXT_PADDING, ARGB_WHITE);
+            drawTextWithShadow(matrices, textRenderer, new TranslatableText("gui.mtr.schedule_sensor_label"), SQUARE_SIZE, SQUARE_SIZE, ARGB_WHITE);
+            drawTextWithShadow(matrices, textRenderer, new TranslatableText("gui.mtr.schedule_sensor_label2"), SQUARE_SIZE, SQUARE_SIZE +50, ARGB_WHITE);
             textFieldMessage.render(matrices, mouseX, mouseY, delta);
+            textFieldMessage2.render(matrices, mouseX, mouseY, delta);
             super.render(matrices, mouseX, mouseY, delta);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/mtr/packet/PacketTrainDataGuiClient.java
+++ b/src/main/java/mtr/packet/PacketTrainDataGuiClient.java
@@ -179,10 +179,11 @@ public class PacketTrainDataGuiClient extends PacketTrainDataBase {
 		sendUpdate(packetId, packet);
 	}
 
-	public static void sendScheduleSensorC2S(BlockPos pos, String message) {
+	public static void sendScheduleSensorC2S(BlockPos pos, String offset, String dest) {
 		final PacketByteBuf packet = PacketByteBufs.create();
 		packet.writeBlockPos(pos);
-		packet.writeString(message);
+		packet.writeString(offset);
+		packet.writeString(dest);
 		ClientPlayNetworking.send(PACKET_SCHEDULE_SENSOR_UPDATE, packet);
 	}
 

--- a/src/main/java/mtr/packet/PacketTrainDataGuiServer.java
+++ b/src/main/java/mtr/packet/PacketTrainDataGuiServer.java
@@ -192,11 +192,13 @@ public class PacketTrainDataGuiServer extends PacketTrainDataBase {
 
 	public static void receiveScheduleSensorC2S(MinecraftServer minecraftServer, ServerPlayerEntity player, PacketByteBuf packet) {
 		final BlockPos pos = packet.readBlockPos();
-		final String message = packet.readString(SerializedDataBase.PACKET_STRING_READ_LENGTH);
+		final String offset = packet.readString(SerializedDataBase.PACKET_STRING_READ_LENGTH);
+		final String dest = packet.readString(SerializedDataBase.PACKET_STRING_READ_LENGTH);
 		minecraftServer.execute(() -> {
 			final BlockEntity entity = player.world.getBlockEntity(pos);
 			if (entity instanceof BlockScheduleSensor.TileEntityBlockScheduleSensor) {
-				(( BlockScheduleSensor.TileEntityBlockScheduleSensor) entity).setMessage(message);
+				(( BlockScheduleSensor.TileEntityBlockScheduleSensor) entity).setOffSet(offset);
+				(( BlockScheduleSensor.TileEntityBlockScheduleSensor) entity).setDest(dest);
 			}
 		});
 	}

--- a/src/main/resources/assets/mtr/lang/en_us.json
+++ b/src/main/resources/assets/mtr/lang/en_us.json
@@ -162,6 +162,7 @@
 	"gui.mtr.routes": "Routes",
 	"gui.mtr.s": "s",
 	"gui.mtr.schedule_sensor_label": "Arrival Offset (Seconds)",
+	"gui.mtr.schedule_sensor_label2": "Destination Filter",
 	"gui.mtr.search": "Search",
 	"gui.mtr.selected": "Selected",
 	"gui.mtr.selected_train": "Selected Train",


### PR DESCRIPTION
Adds an (optional) Destination Filter option so the sensor bar will only fire redstone signal if both the arrival offset and destination tag match the train that is arriving. e.g usage... Fire command blocks to play sounds relevant to the destination of the train. Also can be used at terminating stations to trigger command blocks to play "This train terminates here" style announcements.