### PR TITLE
Balancing change in survival mode

### DIFF
--- a/common/src/main/java/mtr/Items.java
+++ b/common/src/main/java/mtr/Items.java
@@ -6,6 +6,7 @@ import mtr.item.*;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.WaterLilyBlockItem;
+import java.util.HashMap;
 
 public interface Items {
 
@@ -42,6 +43,34 @@ public interface Items {
 	Item RAIL_CONNECTOR_PLATFORM = new ItemRailModifier(false, RailType.PLATFORM);
 	Item RAIL_CONNECTOR_SIDING = new ItemRailModifier(false, RailType.SIDING);
 	Item RAIL_CONNECTOR_TURN_BACK = new ItemRailModifier(false, RailType.TURN_BACK);
+	HashMap<RailType, Item> RAIL_CONNECTOR_HashMapItem = new HashMap<RailType, Item>() {
+		{
+			put(RailType.NONE, null);
+			put(RailType.WOODEN, Items.RAIL_CONNECTOR_20);
+			put(RailType.STONE, Items.RAIL_CONNECTOR_40);
+			put(RailType.EMERALD, Items.RAIL_CONNECTOR_60);
+			put(RailType.IRON, Items.RAIL_CONNECTOR_80);
+			put(RailType.OBSIDIAN, Items.RAIL_CONNECTOR_120);
+			put(RailType.BLAZE, Items.RAIL_CONNECTOR_160);
+			put(RailType.QUARTZ, Items.RAIL_CONNECTOR_200);
+			put(RailType.DIAMOND, Items.RAIL_CONNECTOR_300);
+			put(RailType.PLATFORM, Items.RAIL_CONNECTOR_PLATFORM);
+			put(RailType.SIDING, Items.RAIL_CONNECTOR_SIDING);
+			put(RailType.TURN_BACK, Items.RAIL_CONNECTOR_TURN_BACK);
+		}
+	};
+	HashMap<RailType, Item> RAIL_CONNECTOR_ONE_WAY_HashMapItem = new HashMap<RailType, Item>() {
+		{
+			put(RailType.WOODEN, Items.RAIL_CONNECTOR_20_ONE_WAY);
+			put(RailType.STONE, Items.RAIL_CONNECTOR_40_ONE_WAY);
+			put(RailType.EMERALD, Items.RAIL_CONNECTOR_60_ONE_WAY);
+			put(RailType.IRON, Items.RAIL_CONNECTOR_80_ONE_WAY);
+			put(RailType.OBSIDIAN, Items.RAIL_CONNECTOR_120_ONE_WAY);
+			put(RailType.BLAZE, Items.RAIL_CONNECTOR_160_ONE_WAY);
+			put(RailType.QUARTZ, Items.RAIL_CONNECTOR_200_ONE_WAY);
+			put(RailType.DIAMOND, Items.RAIL_CONNECTOR_300_ONE_WAY);
+		}
+	};
 	Item RAIL_REMOVER = new ItemRailModifier();
 	Item RESOURCE_PACK_CREATOR = new ItemResourcePackCreator(new Item.Properties().tab(ItemGroups.CORE));
 	Item SIGNAL_CONNECTOR_WHITE = new ItemSignalModifier(true, DyeColor.WHITE);

--- a/common/src/main/java/mtr/data/RailwayData.java
+++ b/common/src/main/java/mtr/data/RailwayData.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
@@ -498,6 +499,10 @@ public class RailwayData extends PersistentStateMapper implements IPacket {
 		return containsRail(rails, pos1, pos2);
 	}
 
+	public Rail getRail(BlockPos pos1, BlockPos pos2) {
+		return getRail(rails, pos1, pos2);
+	}
+
 	public long removeSignal(DyeColor color, BlockPos posStart, BlockPos posEnd) {
 		return signalBlocks.remove(0, color, PathData.getRailProduct(posStart, posEnd));
 	}
@@ -662,6 +667,14 @@ public class RailwayData extends PersistentStateMapper implements IPacket {
 
 	public static boolean containsRail(Map<BlockPos, Map<BlockPos, Rail>> rails, BlockPos pos1, BlockPos pos2) {
 		return rails.containsKey(pos1) && rails.get(pos1).containsKey(pos2);
+	}
+
+	public @Nullable Rail getRail(Map<BlockPos, Map<BlockPos, Rail>> rails, BlockPos pos1, BlockPos pos2) {
+		if (containsRail(rails, pos1, pos2)) {
+			return rails.get(pos1).get(pos2);
+		} else {
+			return null;
+		}
 	}
 
 	public static Station getStation(Set<Station> stations, DataCache dataCache, BlockPos pos) {

--- a/common/src/main/java/mtr/item/ItemNodeModifierBase.java
+++ b/common/src/main/java/mtr/item/ItemNodeModifierBase.java
@@ -20,6 +20,7 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -31,7 +32,7 @@ public abstract class ItemNodeModifierBase extends Item {
 	private static final String TAG_TRANSPORT_MODE = "transport_mode";
 
 	public ItemNodeModifierBase(boolean isConnector) {
-		super(new Item.Properties().tab(ItemGroups.CORE).stacksTo(1));
+		super(new Item.Properties().tab(ItemGroups.CORE).stacksTo(64));
 		this.isConnector = isConnector;
 	}
 
@@ -66,7 +67,7 @@ public abstract class ItemNodeModifierBase extends Item {
 								onConnect(world, context.getItemInHand(), ((BlockNode) blockStart).transportMode, stateStart, stateEnd, posStart, posEnd, railAngleStart, railAngleEnd, player, railwayData);
 							}
 						} else {
-							onRemove(world, posStart, posEnd, railwayData);
+							onRemove(world, player, posStart, posEnd, railwayData);
 						}
 					}
 
@@ -97,5 +98,5 @@ public abstract class ItemNodeModifierBase extends Item {
 
 	protected abstract void onConnect(Level world, ItemStack stack, TransportMode transportMode, BlockState stateStart, BlockState stateEnd, BlockPos posStart, BlockPos posEnd, RailAngle facingStart, RailAngle facingEnd, Player player, RailwayData railwayData);
 
-	protected abstract void onRemove(Level world, BlockPos posStart, BlockPos posEnd, RailwayData railwayData);
+	protected abstract void onRemove(Level world, @Nullable Player player, BlockPos posStart, BlockPos posEnd, RailwayData railwayData);
 }

--- a/common/src/main/java/mtr/item/ItemNodeModifierSelectableBlockBase.java
+++ b/common/src/main/java/mtr/item/ItemNodeModifierSelectableBlockBase.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -93,7 +94,7 @@ public abstract class ItemNodeModifierSelectableBlockBase extends ItemNodeModifi
 	}
 
 	@Override
-	protected final void onRemove(Level world, BlockPos posStart, BlockPos posEnd, RailwayData railwayData) {
+	protected final void onRemove(Level world, @Nullable Player player, BlockPos posStart, BlockPos posEnd, RailwayData railwayData) {
 	}
 
 	protected BlockState getSavedState(ItemStack stack) {

--- a/common/src/main/java/mtr/item/ItemSignalModifier.java
+++ b/common/src/main/java/mtr/item/ItemSignalModifier.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemSignalModifier extends ItemNodeModifierBase {
 
@@ -32,7 +33,7 @@ public class ItemSignalModifier extends ItemNodeModifierBase {
 	}
 
 	@Override
-	protected void onRemove(Level world, BlockPos posStart, BlockPos posEnd, RailwayData railwayData) {
+	protected void onRemove(Level world, @Nullable Player player, BlockPos posStart, BlockPos posEnd, RailwayData railwayData) {
 		PacketTrainDataGuiServer.removeSignalS2C(world, railwayData.removeSignal(color, posStart, posEnd), color, PathData.getRailProduct(posStart, posEnd));
 	}
 }


### PR DESCRIPTION
- Make Rail connector stackable
- Consume Rail connector in survival mode
- Give Rail connector back when properly removed (Use another connector or remover, but exclude remove the node)

Ref: [Discord Suggestions](https://discord.com/channels/763273460465270816/801256122454769664/944609131279552514)

The reason why I made this is due to I am playing this mod in survival mode, and I found it is so OP.
The node is very cheap, and the connector can be used forever.
What if we change the connector to one rail one connector?
if I were the designer, I would change the connector to one connector for one rail, and make it stackable.
also I would like to make the node more expensive.

Because MTR is much stronger than vanilla rail system, so it should be much more expensive.