### PR TITLE
Use Jsdelivr CDN for fonts and javascript libraries

### DIFF
--- a/common/src/main/resources/assets/mtr/website/index.html
+++ b/common/src/main/resources/assets/mtr/website/index.html
@@ -5,14 +5,14 @@
 	<meta charset="UTF-8">
 	<title>Railway System Map</title>
 	<link rel="stylesheet" href="index.css">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Sans">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif+TC">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif+SC">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif+JP">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif+KR">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/noto-sans/400.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-tc/400.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-sc/400.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-jp/400.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-kr/400.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/material-icons/400.css">
 	<link rel="icon" type="image/png" href="../../../../../../../forge/src/main/resources/icon.png"/>
-	<script src="https://pixijs.download/release/pixi.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/pixi.js@6.2.2/dist/browser/pixi.min.js"></script>
 	<script type="module" src="index.js"></script>
 	<script type="module" src="drawing.js"></script>
 	<script type="module" src="directions.js"></script>


### PR DESCRIPTION
This is primarily to make the online system map accessible to players in CN.
JSDelivr has servers in CN currently, while also having decent servers worldwide.