### PR TITLE
Fix quartz/200 rail connector recipe

### DIFF
--- a/common/src/main/resources/data/mtr/recipes/rail_connector_200.json
+++ b/common/src/main/resources/data/mtr/recipes/rail_connector_200.json
@@ -17,6 +17,6 @@
 		}
 	},
 	"result": {
-		"item": "mtr:rail_connector_200_one_way"
+		"item": "mtr:rail_connector_200"
 	}
 }


### PR DESCRIPTION
It mistakenly resulted in the one-way variant.