### PR TITLE
允许持钥匙玩家无视任何条件上车 | Allow the player holding the key to board the train at any time

### DIFF
--- a/common/src/main/java/mtr/data/LiftServer.java
+++ b/common/src/main/java/mtr/data/LiftServer.java
@@ -35,7 +35,7 @@ public class LiftServer extends Lift {
 		tick(world, 1);
 
 		final int ridingEntitiesCount = ridingEntities.size();
-		VehicleRidingServer.mountRider(world, ridingEntities, id, 1, currentPositionX + liftOffsetX / 2F, currentPositionY + liftOffsetY, currentPositionZ + liftOffsetZ / 2F, liftWidth - 1, liftDepth - 1, getYaw(), 0, doorValue > 0, true, 0, PACKET_UPDATE_LIFT_PASSENGERS, player -> true, player -> {
+		VehicleRidingServer.mountRider(world, ridingEntities, id, 1, currentPositionX + liftOffsetX / 2F, currentPositionY + liftOffsetY, currentPositionZ + liftOffsetZ / 2F, liftWidth - 1, liftDepth - 1, getYaw(), 0, doorValue > 0, 0, PACKET_UPDATE_LIFT_PASSENGERS, player -> true, player -> {
 		});
 
 		if (liftInstructions.isDirty() || ridingEntitiesCount != ridingEntities.size()) {

--- a/common/src/main/java/mtr/data/TrainServer.java
+++ b/common/src/main/java/mtr/data/TrainServer.java
@@ -107,7 +107,7 @@ public class TrainServer extends Train {
 			double prevCarX, double prevCarY, double prevCarZ, float prevCarYaw, float prevCarPitch,
 			boolean doorLeftOpen, boolean doorRightOpen, double realSpacing
 	) {
-		VehicleRidingServer.mountRider(world, ridingEntities, id, routeId, carX, carY, carZ, realSpacing, width, carYaw, carPitch, doorLeftOpen || doorRightOpen, isManualAllowed || doorLeftOpen || doorRightOpen, ridingCar, PACKET_UPDATE_TRAIN_PASSENGERS, player -> !isManualAllowed || doorLeftOpen || doorRightOpen || Train.isHoldingKey(player), player -> {
+		VehicleRidingServer.mountRider(world, ridingEntities, id, routeId, carX, carY, carZ, realSpacing, width, carYaw, carPitch, doorLeftOpen || doorRightOpen, ridingCar, PACKET_UPDATE_TRAIN_PASSENGERS, player -> Train.isHoldingKey(player) || doorLeftOpen || doorRightOpen, player -> {
 			if (isHoldingKey(player)) {
 				manualCoolDown = 0;
 			}


### PR DESCRIPTION
## 中文版

当前 MTR 模组的规则是：只有手动驾驶的列车，才允许玩家持钥匙上车。

鉴于：

- 玩家常有录制列车 POV 的需求，一般从车厂侧线开始录制；这时如果手动驾驶，就会使得录制变得不方便；
- 在不设手动驾驶列车的车厂，玩家可能需要观察自动驾驶列车的运行（包括铁路限速）是否正确。

建议 MTR 模组默认允许持钥匙的玩家，无论列车是否为手动，无论列车在车厂还是线路，无论列车是关门还是开门，都能上车。

## English Version

The current rule of the MTR mod is: only manually driven trains allow players to board at any time with a key.

Considering:

- Players often need to record train POV, generally starting from the train depot siding. If they drive manually at this time, it makes recording inconvenient;
- In depots where there are no manually driven trains, players may need to observe whether the operation of the automatic trains (including rail speed limits) is correct.

I suggest that the MTR mod should by default allow players with a key to board, regardless of whether the train is manually or automatically driven, whether the train is in the depot or on the route, and whether the train doors are open or closed.