### PR TITLE
feat: Make lift textures data driven and selectable in-game

### DIFF
--- a/buildSrc/src/main/resources/schema/resource/liftResource.json
+++ b/buildSrc/src/main/resources/schema/resource/liftResource.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "javaImplements": [
+        "SerializedDataBase"
+    ],
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "textureResource": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string"
+        },
+        "color": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "id",
+        "textureResource",
+        "name"
+    ]
+}

--- a/fabric/src/main/java/org/mtr/mod/item/ItemLiftRefresher.java
+++ b/fabric/src/main/java/org/mtr/mod/item/ItemLiftRefresher.java
@@ -14,6 +14,7 @@ import org.mtr.mapping.mapper.ItemExtension;
 import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockLiftTrackBase;
 import org.mtr.mod.block.BlockLiftTrackFloor;
+import org.mtr.mod.client.CustomResourceLoader;
 import org.mtr.mod.client.MinecraftClientData;
 import org.mtr.mod.generated.lang.TranslationProvider;
 import org.mtr.mod.packet.PacketOpenLiftCustomizationScreen;
@@ -141,6 +142,7 @@ public class ItemLiftRefresher extends ItemExtension implements DirectionHelper 
 		final Lift lift = new Lift(new MinecraftClientData());
 		lift.setFloors(liftFloors);
 		lift.setDimensions(3, 2, 2, 0, 0, 0);
+		lift.setStyle(CustomResourceLoader.DEFAULT_LIFT_ID);
 		Init.sendMessageC2S(OperationProcessor.GENERATE_BY_LIFT, serverWorld.getServer(), new World(serverWorld.data), lift, null, null);
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/render/RenderLifts.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderLifts.java
@@ -17,6 +17,7 @@ import org.mtr.mapping.mapper.OptimizedRenderer;
 import org.mtr.mod.Init;
 import org.mtr.mod.Items;
 import org.mtr.mod.block.BlockLiftTrackFloor;
+import org.mtr.mod.client.CustomResourceLoader;
 import org.mtr.mod.client.IDrawing;
 import org.mtr.mod.client.MinecraftClientData;
 import org.mtr.mod.client.VehicleRidingMovement;
@@ -24,13 +25,14 @@ import org.mtr.mod.data.IGui;
 import org.mtr.mod.item.ItemLiftRefresher;
 import org.mtr.mod.model.ModelLift1;
 import org.mtr.mod.model.ModelSmallCube;
+import org.mtr.mod.resource.LiftResource;
 
+import javax.annotation.Nullable;
 import java.util.function.Function;
 
 public class RenderLifts implements IGui {
 
 	private static final int LIFT_DISPLAY_COLOR = 0xFFFF0000;
-	private static final Identifier LIFT_TEXTURE = new Identifier(Init.MOD_ID, "textures/vehicle/lift_1.png");
 	private static final ModelSmallCube MODEL_SMALL_CUBE = new ModelSmallCube(new Identifier("textures/block/redstone_block.png"));
 	private static final float LIFT_DOOR_VALUE = 0.75F;
 	private static final float LIFT_FLOOR_PADDING = 0.25F;
@@ -52,6 +54,11 @@ public class RenderLifts implements IGui {
 
 		MinecraftClientData.getInstance().liftWrapperList.values().forEach(liftWrapper -> {
 			final Lift lift = liftWrapper.getLift();
+			LiftResource liftResource = getLift(lift.getStyle());
+			if (liftResource == null) {
+				liftResource = getLift(CustomResourceLoader.DEFAULT_LIFT_ID);
+			}
+			final Identifier LIFT_TEXTURE = liftResource.getTexture();
 
 			if (isHoldingRefresher) {
 				// Render lift path for debugging
@@ -245,5 +252,15 @@ public class RenderLifts implements IGui {
 				position.y + lift.getOffsetY(),
 				position.z + lift.getOffsetZ()
 		), -Math.PI / 2 - lift.getAngle().angleRadians, 0);
+	}
+
+	public static LiftResource getLift(@Nullable String liftId) {
+		if (liftId == null) {
+			return null;
+		} else {
+			final LiftResource[] liftResource = {null};
+			CustomResourceLoader.getLiftById(liftId, newLiftResource -> liftResource[0] = newLiftResource);
+			return liftResource[0];
+		}
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/resource/LiftResource.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/LiftResource.java
@@ -1,0 +1,31 @@
+package org.mtr.mod.resource;
+
+import org.mtr.core.serializer.ReaderBase;
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.holder.MutableText;
+import org.mtr.mapping.mapper.TextHelper;
+import org.mtr.mod.generated.resource.LiftResourceSchema;
+
+public final class LiftResource extends LiftResourceSchema {
+
+    public LiftResource(ReaderBase readerBase) {
+        super(readerBase);
+        updateData(readerBase);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Identifier getTexture() {
+        return CustomResourceTools.formatIdentifierWithDefault(textureResource, "png");
+    }
+
+    public MutableText getName() {
+        return TextHelper.translatable(name);
+    }
+
+    public int getColor() {
+        return CustomResourceTools.colorStringToInt(color);
+    }
+}

--- a/fabric/src/main/java/org/mtr/mod/screen/LiftCustomizationScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/LiftCustomizationScreen.java
@@ -3,11 +3,7 @@ package org.mtr.mod.screen;
 import org.mtr.core.data.Lift;
 import org.mtr.core.operation.UpdateDataRequest;
 import org.mtr.core.tool.Angle;
-import org.mtr.core.tool.EnumHelper;
-import org.mtr.mapping.holder.ClickableWidget;
-import org.mtr.mapping.holder.Direction;
-import org.mtr.mapping.holder.MutableText;
-import org.mtr.mapping.holder.Text;
+import org.mtr.mapping.holder.*;
 import org.mtr.mapping.mapper.*;
 import org.mtr.mod.InitClient;
 import org.mtr.mod.client.IDrawing;
@@ -15,12 +11,10 @@ import org.mtr.mod.client.MinecraftClientData;
 import org.mtr.mod.data.IGui;
 import org.mtr.mod.generated.lang.TranslationProvider;
 import org.mtr.mod.packet.PacketUpdateData;
-
-import java.util.Locale;
+import org.mtr.mod.render.RenderLifts;
 
 public class LiftCustomizationScreen extends MTRScreenBase implements IGui {
 
-	private LiftStyle liftStyle;
 	private Direction liftDirection;
 
 	private final Lift lift;
@@ -50,7 +44,6 @@ public class LiftCustomizationScreen extends MTRScreenBase implements IGui {
 	public LiftCustomizationScreen(Lift lift) {
 		super();
 		this.lift = lift;
-		liftStyle = EnumHelper.valueOf(LiftStyle.TRANSPARENT, lift.getStyle());
 		liftDirection = Direction.fromRotation(lift.getAngle().angleDegrees);
 
 		buttonHeightMinus = new ButtonWidgetExtension(0, 0, 0, SQUARE_SIZE, TextHelper.literal("-"), button -> {
@@ -111,10 +104,8 @@ public class LiftCustomizationScreen extends MTRScreenBase implements IGui {
 		});
 		buttonIsDoubleSided.setMessage2(new Text(doubleSidedText.data));
 		buttonLiftStyle = new ButtonWidgetExtension(0, 0, 0, SQUARE_SIZE, button -> {
-			liftStyle = LiftStyle.values()[(liftStyle.ordinal() + 1) % LiftStyle.values().length];
-			lift.setStyle(liftStyle.toString());
-			updateControls(true);
-		});
+            MinecraftClient.getInstance().openScreen(new Screen(LiftStyleSelectorScreen.create(lift)));
+        });
 		buttonRotateAnticlockwise = new ButtonWidgetExtension(0, 0, 0, SQUARE_SIZE, rotateAnticlockwiseText, button -> {
 			liftDirection = liftDirection.rotateYCounterclockwise();
 			lift.setAngle(Angle.fromAngle(liftDirection.asRotation()));
@@ -164,7 +155,7 @@ public class LiftCustomizationScreen extends MTRScreenBase implements IGui {
 		addChild(new ClickableWidget(buttonOffsetZMinus));
 		addChild(new ClickableWidget(buttonOffsetZAdd));
 		addChild(new ClickableWidget(buttonIsDoubleSided));
-//		addChild(new ClickableWidget(buttonLiftStyle));
+		addChild(new ClickableWidget(buttonLiftStyle));
 		addChild(new ClickableWidget(buttonRotateAnticlockwise));
 		addChild(new ClickableWidget(buttonRotateClockwise));
 		updateControls(false);
@@ -204,12 +195,10 @@ public class LiftCustomizationScreen extends MTRScreenBase implements IGui {
 		buttonOffsetZMinus.active = lift.getOffsetZ() > -MAX_OFFSET;
 		buttonOffsetZAdd.active = lift.getOffsetZ() < MAX_OFFSET;
 		buttonIsDoubleSided.setChecked(lift.getIsDoubleSided());
-		buttonLiftStyle.setMessage2(TranslationProvider.GUI_MTR_LIFT_STYLE.getText(lift.getStyle().toUpperCase(Locale.ENGLISH)));
+		buttonLiftStyle.setMessage2(Text.of(RenderLifts.getLift(lift.getStyle()).getName().getString()));
 
 		if (sendUpdate) {
 			InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketUpdateData(new UpdateDataRequest(MinecraftClientData.getInstance()).addLift(lift)));
 		}
 	}
-
-	private enum LiftStyle {TRANSPARENT, OPAQUE}
 }

--- a/fabric/src/main/java/org/mtr/mod/screen/LiftStyleSelectorScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/LiftStyleSelectorScreen.java
@@ -1,0 +1,64 @@
+package org.mtr.mod.screen;
+
+import org.mtr.core.data.Lift;
+import org.mtr.core.operation.UpdateDataRequest;
+import org.mtr.libraries.it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectImmutableList;
+import org.mtr.mapping.holder.ClientPlayerEntity;
+import org.mtr.mapping.holder.MinecraftClient;
+import org.mtr.mod.Init;
+import org.mtr.mod.InitClient;
+import org.mtr.mod.client.CustomResourceLoader;
+import org.mtr.mod.client.MinecraftClientData;
+import org.mtr.mod.packet.PacketUpdateData;
+import org.mtr.mod.resource.LiftResource;
+
+import java.util.Objects;
+
+public class LiftStyleSelectorScreen extends DashboardListSelectorScreen {
+
+    private final Lift lift;
+    private final ObjectImmutableList<LiftResource> allLifts = CustomResourceLoader.getLifts();
+
+    private LiftStyleSelectorScreen(Lift lift, ObjectImmutableList<DashboardListItem> lifts, LongArrayList selectedLiftIndicies) {
+        super(lifts, selectedLiftIndicies, true, false, null);
+        this.lift = lift;
+    }
+
+    @Override
+    public void onClose2() {
+        super.onClose2();
+        final ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().getPlayerMapped();
+
+        selectedIds.forEach(index -> {
+            lift.setStyle(allLifts.get((int) index).getId());
+        });
+
+        if (clientPlayerEntity != null) {
+            InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketUpdateData(new UpdateDataRequest(MinecraftClientData.getInstance()).addLift(lift)));
+        }
+    }
+
+    @Override
+    protected void updateList() {
+        super.updateList();
+        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketUpdateData(new UpdateDataRequest(MinecraftClientData.getInstance()).addLift(lift)));
+    }
+
+    public static LiftStyleSelectorScreen create(Lift lift) {
+        final ObjectImmutableList<LiftResource> allLifts = CustomResourceLoader.getLifts();
+        final ObjectArrayList<DashboardListItem> liftsForList = new ObjectArrayList<>();
+        final LongArrayList selectedIds = new LongArrayList();
+
+        for (int i = 0; i < allLifts.size(); i++) {
+            final LiftResource liftResource = allLifts.get(i);
+            liftsForList.add(new DashboardListItem(i, liftResource.getName().getString(), liftResource.getColor() | ARGB_BLACK));
+            if (Objects.equals(liftResource.getId(), lift.getStyle())) {
+                selectedIds.add(i);
+            }
+        }
+
+        return new LiftStyleSelectorScreen(lift, new ObjectImmutableList<>(liftsForList), selectedIds);
+    }
+}

--- a/fabric/src/main/mtr_custom_resources_template.json
+++ b/fabric/src/main/mtr_custom_resources_template.json
@@ -925,5 +925,12 @@
 				"z": 0.15
 			}
 		}
+	],
+	"lifts": [
+		{
+			"id": "default_lift",
+			"textureResource": "mtr:textures/vehicle/lift_1.png",
+			"name": "lift.mtr.default_lift"
+		}
 	]
 }

--- a/fabric/src/main/resources/assets/mtr/lang/en_us.json
+++ b/fabric/src/main/resources/assets/mtr/lang/en_us.json
@@ -521,6 +521,7 @@
 	"key.mtr.train_accelerate": "Accelerate Vehicle",
 	"key.mtr.train_brake": "Brake Vehicle",
 	"key.mtr.train_toggle_doors": "Toggle Doors",
+	"lift.mtr.default_lift": "Default Lift",
 	"options.mtr.anonymous": "Anonymous",
 	"options.mtr.default_rail_3d": "Render default rails in 3D",
 	"options.mtr.disable_shadows_for_shaders": "Disable shadows when using shaders",


### PR DESCRIPTION
This PR adds a basic system for creating lifts through a resource pack's mtr_custom_resources.json and then selecting them in-game. You must specify an id, name, and textureResource, and optionally a colour, which will be displayed in the lift select screen. Currently, this is limited to the texture, however I wish to extend this in the future to also include custom models for lifts too.