### PR TITLE
Add .mqo format support

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/client/CustomResourceLoader.java
+++ b/fabric/src/main/java/org/mtr/mod/client/CustomResourceLoader.java
@@ -26,6 +26,18 @@ public class CustomResourceLoader {
 
 	private static long TEST_DURATION;
 
+	private static final ResourceProvider RESOURCE_PROVIDER = new ResourceProvider() {
+		@Override
+		public String get(Identifier identifier) {
+			return readResource(identifier);
+		}
+
+		@Override
+		public byte[] getBytes(Identifier identifier) {
+			return readResourceBytes(identifier);
+		}
+	};
+
 	public static final OptimizedRendererWrapper OPTIMIZED_RENDERER_WRAPPER = new OptimizedRendererWrapper();
 	public static final String CUSTOM_RESOURCES_ID = "mtr_custom_resources";
 	public static final String CUSTOM_RESOURCES_PENDING_MIGRATION_ID = "mtr_custom_resources_pending_migration";
@@ -77,13 +89,13 @@ public class CustomResourceLoader {
 
 		final ObjectArrayList<SignResource> defaultSigns = new ObjectArrayList<>();
 
-		final RailResource defaultRailResource = new RailResource(DEFAULT_RAIL_ID, "Default", CustomResourceLoader::readResource);
+		final RailResource defaultRailResource = new RailResource(DEFAULT_RAIL_ID, "Default", RESOURCE_PROVIDER);
 		RAILS.add(defaultRailResource);
 		RAILS_CACHE.put(DEFAULT_RAIL_ID, defaultRailResource);
 
 		ResourceManagerHelper.readAllResources(new Identifier(Init.MOD_ID, CUSTOM_RESOURCES_ID + ".json"), inputStream -> {
 			try {
-				final CustomResources customResources = CustomResourcesConverter.convert(Config.readResource(inputStream).getAsJsonObject(), CustomResourceLoader::readResource);
+				final CustomResources customResources = CustomResourcesConverter.convert(Config.readResource(inputStream).getAsJsonObject(), RESOURCE_PROVIDER);
 				customResources.iterateVehicles(vehicleResource -> registerVehicle(vehicleResource, false));
 				customResources.iterateSigns(signResource -> {
 					if (signResource.isDefault) {
@@ -113,7 +125,7 @@ public class CustomResourceLoader {
 		// TODO temporary code for loading models pending migration
 		ResourceManagerHelper.readAllResources(new Identifier(Init.MOD_ID, CUSTOM_RESOURCES_PENDING_MIGRATION_ID + ".json"), inputStream -> {
 			try {
-				CustomResourcesConverter.convert(Config.readResource(inputStream).getAsJsonObject(), CustomResourceLoader::readResource).iterateVehicles(vehicleResource -> registerVehicle(vehicleResource, false));
+				CustomResourcesConverter.convert(Config.readResource(inputStream).getAsJsonObject(), RESOURCE_PROVIDER).iterateVehicles(vehicleResource -> registerVehicle(vehicleResource, false));
 			} catch (Exception e) {
 				Init.LOGGER.error("", e);
 			}
@@ -125,12 +137,12 @@ public class CustomResourceLoader {
 		CustomResourcesConverter.convertRails(railResource -> {
 			RAILS.add(railResource);
 			RAILS_CACHE.put(railResource.getId(), railResource);
-		}, CustomResourceLoader::readResource);
+		}, RESOURCE_PROVIDER);
 
 		CustomResourcesConverter.convertObjects(objectResource -> {
 			OBJECTS.add(objectResource);
 			OBJECTS_CACHE.put(objectResource.getId(), objectResource);
-		}, CustomResourceLoader::readResource);
+		}, RESOURCE_PROVIDER);
 
 		VEHICLES.forEach((transportMode, vehicleResources) -> validateDataset("Vehicle", vehicleResources, VehicleResource::getId));
 		validateDataset("Sign", SIGNS, signResource -> signResource.signId);
@@ -334,6 +346,27 @@ public class CustomResourceLoader {
 			}
 		} else {
 			return cache;
+		}
+	}
+
+	private static byte[] readResourceBytes(Identifier identifier) {
+		if (Keys.DEBUG) {
+			try (final InputStream inputStream = Files.newInputStream(MinecraftClient.getInstance().getRunDirectoryMapped().toPath().resolve("../src/main/resources/assets").resolve(identifier.getNamespace()).resolve(identifier.getPath()), StandardOpenOption.READ)) {
+				return IOUtils.toByteArray(inputStream);
+			} catch (Exception e) {
+				Init.LOGGER.error("", e);
+				return new byte[0];
+			}
+		} else {
+			final byte[][] bytes = new byte[1][];
+			ResourceManagerHelper.readResource(identifier, inputStream -> {
+				try {
+					bytes[0] = IOUtils.toByteArray(inputStream);
+				} catch (Exception e) {
+					Init.LOGGER.error("", e);
+				}
+			});
+			return bytes[0] == null ? new byte[0] : bytes[0];
 		}
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/resource/ModelResourceLoader.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/ModelResourceLoader.java
@@ -1,15 +1,22 @@
 package org.mtr.mod.resource;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.mapper.OptimizedModel;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
 public final class ModelResourceLoader {
 
 	public static boolean isObjOrMqo(String modelResource) {
-		return modelResource.endsWith(".obj") || modelResource.endsWith(".mqo");
+		return modelResource.endsWith(".obj") || modelResource.endsWith(".mqo") || modelResource.endsWith(".mqoz");
 	}
 
 	public static Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> loadObjOrMqo(
@@ -18,8 +25,8 @@ public final class ModelResourceLoader {
 			boolean flipTextureV,
 			ResourceProvider resourceProvider
 	) {
-		if (modelResource.endsWith(".mqo")) {
-			final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "mqo")));
+		if (modelResource.endsWith(".mqo") || modelResource.endsWith(".mqoz")) {
+			final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(getMqoContent(modelResource, resourceProvider));
 			return new Object2ObjectAVLTreeMap<>(OptimizedModel.ObjModel.loadModel(
 					convertedModel.getObjContent(),
 					mtlString -> convertedModel.getMtlContent(),
@@ -39,11 +46,80 @@ public final class ModelResourceLoader {
 	public static ObjectArrayList<String> getModelParts(String name, String content) {
 		if (name.endsWith(".mqo")) {
 			return MqoModelConverter.convert(content).getModelParts();
+		} else if (name.endsWith(".mqoz")) {
+			return getModelParts(name, content.getBytes(StandardCharsets.UTF_8));
 		} else {
 			return new ObjectArrayList<>(OptimizedModel.ObjModel.loadModel(content, mtlString -> "", textureString -> new Identifier(""), null, true, false).keySet());
 		}
 	}
 
+	public static ObjectArrayList<String> getModelParts(String name, byte[] bytes) {
+		if (name.endsWith(".mqoz")) {
+			return MqoModelConverter.convert(extractMqoContentFromMqoz(name, bytes)).getModelParts();
+		} else {
+			return getModelParts(name, new String(bytes, StandardCharsets.UTF_8));
+		}
+	}
+
+	public static String extractMqoContentFromMqoz(String modelResource, byte[] bytes) {
+		final ObjectArrayList<MqozEntry> mqoEntries = new ObjectArrayList<>();
+		try (final ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(bytes))) {
+			ZipEntry zipEntry;
+			while ((zipEntry = zipInputStream.getNextEntry()) != null) {
+				if (!zipEntry.isDirectory() && zipEntry.getName().toLowerCase().endsWith(".mqo")) {
+					mqoEntries.add(new MqozEntry(zipEntry.getName(), new String(IOUtils.toByteArray(zipInputStream), StandardCharsets.UTF_8)));
+				}
+				zipInputStream.closeEntry();
+			}
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Invalid MQOZ archive", e);
+		}
+
+		if (mqoEntries.isEmpty()) {
+			throw new IllegalArgumentException("MQOZ archive does not contain an MQO file");
+		}
+
+		final String modelBaseName = getFileBaseName(modelResource);
+		mqoEntries.sort(Comparator.comparing(entry -> entry.name));
+		for (final MqozEntry entry : mqoEntries) {
+			if (StringUtils.equals(getFileBaseName(entry.name), modelBaseName)) {
+				return entry.content;
+			}
+		}
+		return mqoEntries.get(0).content;
+	}
+
+	private static String getMqoContent(String modelResource, ResourceProvider resourceProvider) {
+		if (modelResource.endsWith(".mqoz")) {
+			return extractMqoContentFromMqoz(modelResource, resourceProvider.getBytes(CustomResourceTools.formatIdentifierWithDefault(modelResource, "mqoz")));
+		} else {
+			return resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "mqo"));
+		}
+	}
+
+	private static String getFileBaseName(String path) {
+		String normalizedPath = path.replace('\\', '/');
+		final int namespaceIndex = normalizedPath.indexOf(':');
+		if (namespaceIndex >= 0) {
+			normalizedPath = normalizedPath.substring(namespaceIndex + 1);
+		}
+		final String[] pathSplit = normalizedPath.split("/");
+		final String fileName = pathSplit[pathSplit.length - 1];
+		final int extensionIndex = fileName.lastIndexOf('.');
+		return extensionIndex < 0 ? fileName : fileName.substring(0, extensionIndex);
+	}
+
 	private ModelResourceLoader() {
+	}
+
+	private static final class MqozEntry {
+
+		private final String name;
+		private final String content;
+
+		private MqozEntry(String name, String content) {
+			this.name = name;
+			this.content = content;
+		}
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/resource/ModelResourceLoader.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/ModelResourceLoader.java
@@ -15,11 +15,11 @@ import java.util.zip.ZipInputStream;
 
 public final class ModelResourceLoader {
 
-	public static boolean isObjOrMqo(String modelResource) {
+	public static boolean isSupportedModelResource(String modelResource) {
 		return modelResource.endsWith(".obj") || modelResource.endsWith(".mqo") || modelResource.endsWith(".mqoz");
 	}
 
-	public static Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> loadObjOrMqo(
+	public static Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> loadModel(
 			String modelResource,
 			Identifier textureId,
 			boolean flipTextureV,

--- a/fabric/src/main/java/org/mtr/mod/resource/ModelResourceLoader.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/ModelResourceLoader.java
@@ -1,0 +1,49 @@
+package org.mtr.mod.resource;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.mapper.OptimizedModel;
+
+public final class ModelResourceLoader {
+
+	public static boolean isObjOrMqo(String modelResource) {
+		return modelResource.endsWith(".obj") || modelResource.endsWith(".mqo");
+	}
+
+	public static Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> loadObjOrMqo(
+			String modelResource,
+			Identifier textureId,
+			boolean flipTextureV,
+			ResourceProvider resourceProvider
+	) {
+		if (modelResource.endsWith(".mqo")) {
+			final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "mqo")));
+			return new Object2ObjectAVLTreeMap<>(OptimizedModel.ObjModel.loadModel(
+					convertedModel.getObjContent(),
+					mtlString -> convertedModel.getMtlContent(),
+					textureString -> StringUtils.isEmpty(textureString) ? OptimizedModelWrapper.WHITE_TEXTURE : StringUtils.equals(textureString, "default.png") ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
+					null, true, flipTextureV
+			));
+		} else {
+			return new Object2ObjectAVLTreeMap<>(OptimizedModel.ObjModel.loadModel(
+					resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "obj")),
+					mtlString -> resourceProvider.get(CustomResourceTools.getResourceFromSamePath(modelResource, mtlString, "mtl")),
+					textureString -> StringUtils.isEmpty(textureString) ? OptimizedModelWrapper.WHITE_TEXTURE : StringUtils.equals(textureString, "default.png") ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
+					null, true, flipTextureV
+			));
+		}
+	}
+
+	public static ObjectArrayList<String> getModelParts(String name, String content) {
+		if (name.endsWith(".mqo")) {
+			return MqoModelConverter.convert(content).getModelParts();
+		} else {
+			return new ObjectArrayList<>(OptimizedModel.ObjModel.loadModel(content, mtlString -> "", textureString -> new Identifier(""), null, true, false).keySet());
+		}
+	}
+
+	private ModelResourceLoader() {
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/resource/MqoModelConverter.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/MqoModelConverter.java
@@ -1,0 +1,543 @@
+package org.mtr.mod.resource;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class MqoModelConverter {
+
+	private static final Pattern PARAMETER_PATTERN = Pattern.compile("([A-Za-z_][A-Za-z0-9_]*)\\(([^)]*)\\)");
+	private static final double MQO_TO_OBJ_SCALE = 0.01;
+
+	public static ConvertedModel convert(String content) {
+		final String[] lines = content.replace("\r\n", "\n").replace('\r', '\n').split("\n");
+		final Parser parser = new Parser(lines);
+		parser.validateHeader();
+		parser.parseRootChunks();
+		return parser.toConvertedModel();
+	}
+
+	private static String extractQuotedOrFirstToken(String text) {
+		final String trimmedText = text.trim();
+		if (trimmedText.startsWith("\"")) {
+			final int endIndex = findStringEnd(trimmedText, 1);
+			return endIndex < 0 ? trimmedText.substring(1) : trimmedText.substring(1, endIndex);
+		} else {
+			final String[] splitText = trimmedText.split("\\s+", 2);
+			return splitText.length == 0 ? "" : splitText[0];
+		}
+	}
+
+	private static int findStringEnd(String text, int startIndex) {
+		boolean escaped = false;
+		for (int i = startIndex; i < text.length(); i++) {
+			final char character = text.charAt(i);
+			if (escaped) {
+				escaped = false;
+			} else if (character == '\\') {
+				escaped = true;
+			} else if (character == '"') {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static String getParameter(String line, String key) {
+		final Matcher matcher = PARAMETER_PATTERN.matcher(line);
+		while (matcher.find()) {
+			if (StringUtils.equals(matcher.group(1), key)) {
+				return matcher.group(2).trim();
+			}
+		}
+		return "";
+	}
+
+	private static boolean isNonZeroSetting(String line) {
+		final String[] splitLine = line.trim().split("\\s+");
+		return splitLine.length > 1 && !StringUtils.equals(splitLine[1], "0");
+	}
+
+	public static final class ConvertedModel {
+
+		private final String objContent;
+		private final String mtlContent;
+		private final ObjectArrayList<String> modelParts;
+
+		private ConvertedModel(String objContent, String mtlContent, ObjectArrayList<String> modelParts) {
+			this.objContent = objContent;
+			this.mtlContent = mtlContent;
+			this.modelParts = modelParts;
+		}
+
+		public String getObjContent() {
+			return objContent;
+		}
+
+		public String getMtlContent() {
+			return mtlContent;
+		}
+
+		public ObjectArrayList<String> getModelParts() {
+			return new ObjectArrayList<>(modelParts);
+		}
+	}
+
+	private static final class Parser {
+
+		private final String[] lines;
+		private final ObjectArrayList<Material> materials = new ObjectArrayList<>();
+		private final ObjectArrayList<MqoObject> objects = new ObjectArrayList<>();
+		private int index;
+
+		private Parser(String[] lines) {
+			this.lines = lines;
+		}
+
+		private void validateHeader() {
+			final String documentLine = nextNonEmptyLine();
+			final String formatLine = nextNonEmptyLine();
+			if (!StringUtils.equals(documentLine, "Metasequoia Document")) {
+				throw new IllegalArgumentException("Invalid MQO header");
+			}
+			if (formatLine == null || !formatLine.startsWith("Format Text ")) {
+				throw new IllegalArgumentException("Only MQO Format Text files are supported");
+			}
+		}
+
+		private void parseRootChunks() {
+			while (index < lines.length) {
+				final String line = lines[index].trim();
+				if (line.startsWith("Material ")) {
+					parseMaterialChunk();
+				} else if (line.startsWith("Object ")) {
+					parseObjectChunk();
+				} else if (line.startsWith("BVertex ") || line.startsWith("Blob ")) {
+					throw new IllegalArgumentException("Unsupported MQO chunk: " + line.split("\\s+")[0]);
+				} else if (line.endsWith("{")) {
+					skipChunk();
+				} else {
+					index++;
+				}
+			}
+		}
+
+		private ConvertedModel toConvertedModel() {
+			final StringBuilder objBuilder = new StringBuilder("mtllib generated.mtl\n");
+			final StringBuilder mtlBuilder = new StringBuilder();
+			final ObjectArrayList<String> modelParts = new ObjectArrayList<>();
+
+			mtlBuilder.append("newmtl mqo_default\nKd 1.000000 1.000000 1.000000\nd 1.000000\n\n");
+			for (int i = 0; i < materials.size(); i++) {
+				final Material material = materials.get(i);
+				mtlBuilder.append("newmtl ").append(getMaterialName(i)).append('\n');
+				mtlBuilder.append(String.format(Locale.US, "Kd %.6f %.6f %.6f%n", material.red * material.diffuse, material.green * material.diffuse, material.blue * material.diffuse));
+				mtlBuilder.append(String.format(Locale.US, "d %.6f%n", material.alpha));
+				if (!material.texture.isEmpty()) {
+					mtlBuilder.append("map_Kd ").append(material.texture).append('\n');
+				}
+				mtlBuilder.append('\n');
+			}
+
+			int vertexOffset = 1;
+			int textureOffset = 1;
+			int normalOffset = 1;
+			for (final MqoObject object : objects) {
+				if (!object.visible || object.vertices.isEmpty() || object.faces.isEmpty()) {
+					continue;
+				}
+
+				String objectName = object.name.isEmpty() ? "Object" : object.name;
+				if (modelParts.contains(objectName)) {
+					int suffix = 2;
+					while (modelParts.contains(objectName + "_" + suffix)) {
+						suffix++;
+					}
+					objectName = objectName + "_" + suffix;
+				}
+				modelParts.add(objectName);
+
+				objBuilder.append("o ").append(objectName).append('\n');
+				objBuilder.append("g ").append(objectName).append('\n');
+				for (final Vertex vertex : object.vertices) {
+					objBuilder.append(String.format(Locale.US, "v %.6f %.6f %.6f%n", vertex.x * MQO_TO_OBJ_SCALE, vertex.y * MQO_TO_OBJ_SCALE, vertex.z * MQO_TO_OBJ_SCALE));
+				}
+
+				final ObjectArrayList<Triangle> triangles = new ObjectArrayList<>();
+				object.faces.forEach(face -> {
+					final int vertexCount = face.vertexIndices.size();
+					for (int i = 1; i < vertexCount - 1; i++) {
+						triangles.add(new Triangle(object.vertices, face, 0, i + 1, i));
+					}
+				});
+
+				for (final Triangle triangle : triangles) {
+					for (int i = 0; i < 3; i++) {
+						final Vector normal = object.shading == 0 ? triangle.normal : getSmoothedNormal(triangles, triangle, triangle.vertexIndices[i], object.facet);
+						objBuilder.append(String.format(Locale.US, "vn %.6f %.6f %.6f%n", normal.x, normal.y, normal.z));
+						triangle.normalIndices[i] = normalOffset++;
+					}
+				}
+
+				for (final Triangle triangle : triangles) {
+					objBuilder.append("usemtl ").append(triangle.materialIndex >= 0 && triangle.materialIndex < materials.size() ? getMaterialName(triangle.materialIndex) : "mqo_default").append('\n');
+					for (int i = 0; i < 3; i++) {
+						if (triangle.hasUv) {
+							objBuilder.append(String.format(Locale.US, "vt %.6f %.6f%n", triangle.u[i], triangle.v[i]));
+							triangle.textureIndices[i] = textureOffset++;
+						}
+					}
+					objBuilder.append("f");
+					for (int i = 0; i < 3; i++) {
+						objBuilder.append(' ').append(vertexOffset + triangle.vertexIndices[i]);
+						if (triangle.hasUv) {
+							objBuilder.append('/').append(triangle.textureIndices[i]).append('/').append(triangle.normalIndices[i]);
+						} else {
+							objBuilder.append("//").append(triangle.normalIndices[i]);
+						}
+					}
+					objBuilder.append('\n');
+				}
+
+				vertexOffset += object.vertices.size();
+			}
+
+			return new ConvertedModel(objBuilder.toString(), mtlBuilder.toString(), modelParts);
+		}
+
+		private String nextNonEmptyLine() {
+			while (index < lines.length) {
+				final String line = lines[index++].trim();
+				if (!line.isEmpty()) {
+					return line;
+				}
+			}
+			return null;
+		}
+
+		private void parseMaterialChunk() {
+			index++;
+			while (index < lines.length) {
+				final String line = lines[index++].trim();
+				if (StringUtils.equals(line, "}")) {
+					return;
+				}
+				if (!line.isEmpty()) {
+					materials.add(Material.parse(line));
+				}
+			}
+			throw new IllegalArgumentException("Unclosed MQO Material chunk");
+		}
+
+		private void parseObjectChunk() {
+			final String objectHeader = lines[index++].trim();
+			final MqoObject object = new MqoObject(extractQuotedOrFirstToken(objectHeader.substring("Object".length()).replace("{", "").trim()));
+
+			while (index < lines.length) {
+				final String line = lines[index].trim();
+				if (StringUtils.equals(line, "}")) {
+					index++;
+					objects.add(object);
+					return;
+				} else if (line.startsWith("visible ")) {
+					object.visible = !line.endsWith(" 0");
+					index++;
+				} else if (line.startsWith("shading ")) {
+					object.shading = parseInt(line, object.shading);
+					index++;
+				} else if (line.startsWith("facet ")) {
+					object.facet = parseDouble(line, object.facet);
+					index++;
+				} else if (line.startsWith("vertex ")) {
+					parseVertexChunk(object);
+				} else if (line.startsWith("face ")) {
+					parseFaceChunk(object);
+				} else if (line.startsWith("BVertex ")) {
+					throw new IllegalArgumentException("Unsupported MQO BVertex chunk");
+				} else if ((line.startsWith("patch ") || line.startsWith("lathe ") || line.startsWith("mirror ")) && isNonZeroSetting(line)) {
+					throw new IllegalArgumentException("Unsupported MQO object setting: " + line);
+				} else if (line.endsWith("{")) {
+					skipChunk();
+				} else {
+					index++;
+				}
+			}
+			throw new IllegalArgumentException("Unclosed MQO Object chunk");
+		}
+
+		private void parseVertexChunk(MqoObject object) {
+			index++;
+			while (index < lines.length) {
+				final String line = lines[index++].trim();
+				if (StringUtils.equals(line, "}")) {
+					return;
+				}
+				final String[] splitLine = line.split("\\s+");
+				if (splitLine.length >= 3) {
+					object.vertices.add(new Vertex(parseDouble(splitLine[0]), parseDouble(splitLine[1]), parseDouble(splitLine[2])));
+				}
+			}
+			throw new IllegalArgumentException("Unclosed MQO vertex chunk");
+		}
+
+		private void parseFaceChunk(MqoObject object) {
+			index++;
+			while (index < lines.length) {
+				final String line = lines[index++].trim();
+				if (StringUtils.equals(line, "}")) {
+					return;
+				}
+				if (!line.isEmpty()) {
+					object.faces.add(Face.parse(line));
+				}
+			}
+			throw new IllegalArgumentException("Unclosed MQO face chunk");
+		}
+
+		private void skipChunk() {
+			int depth = 0;
+			while (index < lines.length) {
+				final String line = lines[index++];
+				for (int i = 0; i < line.length(); i++) {
+					final char character = line.charAt(i);
+					if (character == '{') {
+						depth++;
+					} else if (character == '}') {
+						depth--;
+					}
+				}
+				if (depth <= 0) {
+					return;
+				}
+			}
+			throw new IllegalArgumentException("Unclosed MQO chunk");
+		}
+
+		private static String getMaterialName(int index) {
+			return "mqo_material_" + index;
+		}
+
+		private static double parseDouble(String value) {
+			return Double.parseDouble(value);
+		}
+
+		private static double parseDouble(String line, double fallback) {
+			try {
+				return Double.parseDouble(line.trim().split("\\s+")[1]);
+			} catch (Exception ignored) {
+				return fallback;
+			}
+		}
+
+		private static int parseInt(String line, int fallback) {
+			try {
+				return Integer.parseInt(line.trim().split("\\s+")[1]);
+			} catch (Exception ignored) {
+				return fallback;
+			}
+		}
+	}
+
+	private static final class Material {
+
+		private final double red;
+		private final double green;
+		private final double blue;
+		private final double alpha;
+		private final double diffuse;
+		private final String texture;
+
+		private Material(double red, double green, double blue, double alpha, double diffuse, String texture) {
+			this.red = red;
+			this.green = green;
+			this.blue = blue;
+			this.alpha = alpha;
+			this.diffuse = diffuse;
+			this.texture = texture;
+		}
+
+		private static Material parse(String line) {
+			double red = 1;
+			double green = 1;
+			double blue = 1;
+			double alpha = 1;
+			double diffuse = 1;
+
+			final String color = getParameter(line, "col");
+			if (!color.isEmpty()) {
+				final String[] colorSplit = color.split("\\s+");
+				if (colorSplit.length >= 4) {
+					red = Double.parseDouble(colorSplit[0]);
+					green = Double.parseDouble(colorSplit[1]);
+					blue = Double.parseDouble(colorSplit[2]);
+					alpha = Double.parseDouble(colorSplit[3]);
+				}
+			}
+
+			final String diffuseString = getParameter(line, "dif");
+			if (!diffuseString.isEmpty()) {
+				diffuse = Double.parseDouble(diffuseString);
+			}
+
+			final String texture = extractQuotedOrFirstToken(getParameter(line, "tex"));
+			return new Material(red, green, blue, alpha, diffuse, texture);
+		}
+	}
+
+	private static final class MqoObject {
+
+		private final String name;
+		private final ObjectArrayList<Vertex> vertices = new ObjectArrayList<>();
+		private final ObjectArrayList<Face> faces = new ObjectArrayList<>();
+		private boolean visible = true;
+		private int shading = 1;
+		private double facet = 59.5;
+
+		private MqoObject(String name) {
+			this.name = name;
+		}
+	}
+
+	private static Vector getSmoothedNormal(ObjectArrayList<Triangle> triangles, Triangle baseTriangle, int vertexIndex, double facet) {
+		final double minDot = Math.cos(Math.toRadians(facet));
+		final Vector combinedNormal = new Vector(0, 0, 0);
+		triangles.forEach(triangle -> {
+			if (triangle.hasVertex(vertexIndex) && baseTriangle.normal.dot(triangle.normal) + 1E-6 >= minDot) {
+				combinedNormal.add(triangle.normal);
+			}
+		});
+		return combinedNormal.normalizeOr(baseTriangle.normal);
+	}
+
+	private static final class Triangle {
+
+		private final int[] vertexIndices = new int[3];
+		private final int[] textureIndices = new int[3];
+		private final int[] normalIndices = new int[3];
+		private final double[] u = new double[3];
+		private final double[] v = new double[3];
+		private final int materialIndex;
+		private final boolean hasUv;
+		private final Vector normal;
+
+		private Triangle(ObjectArrayList<Vertex> vertices, Face face, int index1, int index2, int index3) {
+			final int[] sourceIndices = {index1, index2, index3};
+			for (int i = 0; i < 3; i++) {
+				final int sourceIndex = sourceIndices[i];
+				vertexIndices[i] = face.vertexIndices.get(sourceIndex);
+				if (face.uvCoordinates.size() >= face.vertexIndices.size() * 2) {
+					u[i] = face.uvCoordinates.get(sourceIndex * 2);
+					v[i] = face.uvCoordinates.get(sourceIndex * 2 + 1);
+				}
+			}
+			materialIndex = face.materialIndex;
+			hasUv = face.uvCoordinates.size() >= face.vertexIndices.size() * 2;
+			normal = Vector.normal(vertices.get(vertexIndices[0]), vertices.get(vertexIndices[1]), vertices.get(vertexIndices[2]));
+		}
+
+		private boolean hasVertex(int vertexIndex) {
+			return vertexIndices[0] == vertexIndex || vertexIndices[1] == vertexIndex || vertexIndices[2] == vertexIndex;
+		}
+	}
+
+	private static final class Vector {
+
+		private double x;
+		private double y;
+		private double z;
+
+		private Vector(double x, double y, double z) {
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+
+		private static Vector normal(Vertex vertex1, Vertex vertex2, Vertex vertex3) {
+			final double ax = vertex2.x - vertex1.x;
+			final double ay = vertex2.y - vertex1.y;
+			final double az = vertex2.z - vertex1.z;
+			final double bx = vertex3.x - vertex1.x;
+			final double by = vertex3.y - vertex1.y;
+			final double bz = vertex3.z - vertex1.z;
+			return new Vector(ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx).normalizeOr(new Vector(0, 1, 0));
+		}
+
+		private void add(Vector vector) {
+			x += vector.x;
+			y += vector.y;
+			z += vector.z;
+		}
+
+		private double dot(Vector vector) {
+			return x * vector.x + y * vector.y + z * vector.z;
+		}
+
+		private Vector normalizeOr(Vector fallback) {
+			final double length = Math.sqrt(x * x + y * y + z * z);
+			if (length <= 0) {
+				return fallback;
+			} else {
+				return new Vector(x / length, y / length, z / length);
+			}
+		}
+	}
+
+	private static final class Vertex {
+
+		private final double x;
+		private final double y;
+		private final double z;
+
+		private Vertex(double x, double y, double z) {
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+	}
+
+	private static final class Face {
+
+		private final ObjectArrayList<Integer> vertexIndices = new ObjectArrayList<>();
+		private final ObjectArrayList<Double> uvCoordinates = new ObjectArrayList<>();
+		private final int materialIndex;
+
+		private Face(int materialIndex) {
+			this.materialIndex = materialIndex;
+		}
+
+		private static Face parse(String line) {
+			final String[] splitLine = line.split("\\s+", 2);
+			final int vertexCount = Integer.parseInt(splitLine[0]);
+			final int materialIndex = parseIntParameter(getParameter(line, "M"), -1);
+			final Face face = new Face(materialIndex);
+
+			final String vertexIndices = getParameter(line, "V");
+			if (!vertexIndices.isEmpty()) {
+				final String[] vertexIndexSplit = vertexIndices.split("\\s+");
+				for (int i = 0; i < Math.min(vertexCount, vertexIndexSplit.length); i++) {
+					face.vertexIndices.add(Integer.parseInt(vertexIndexSplit[i]));
+				}
+			}
+
+			final String uvCoordinates = getParameter(line, "UV");
+			if (!uvCoordinates.isEmpty()) {
+				for (final String uvCoordinate : uvCoordinates.split("\\s+")) {
+					face.uvCoordinates.add(Double.parseDouble(uvCoordinate));
+				}
+			}
+
+			return face;
+		}
+
+		private static int parseIntParameter(String value, int fallback) {
+			try {
+				return value.isEmpty() ? fallback : Integer.parseInt(value);
+			} catch (Exception ignored) {
+				return fallback;
+			}
+		}
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/resource/ResourceProvider.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/ResourceProvider.java
@@ -3,10 +3,15 @@ package org.mtr.mod.resource;
 import org.mtr.mapping.holder.Identifier;
 
 import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
 
 @FunctionalInterface
 public interface ResourceProvider {
 
 	@Nonnull
 	String get(Identifier identifier);
+
+	default byte[] getBytes(Identifier identifier) {
+		return get(identifier).getBytes(StandardCharsets.UTF_8);
+	}
 }

--- a/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
@@ -1,12 +1,12 @@
 package org.mtr.mod.resource;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mtr.core.serializer.JsonReader;
 import org.mtr.core.tool.Utilities;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.*;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.mapper.OptimizedModel;
 import org.mtr.mapping.mapper.OptimizedRenderer;
+import org.mtr.mod.Init;
 import org.mtr.mod.client.CustomResourceLoader;
 import org.mtr.mod.render.DynamicVehicleModel;
 import org.mtr.mod.render.MainRenderer;
@@ -21,9 +21,9 @@ public interface StoredModelResourceBase {
 		CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
 
 		final boolean isBlockbench = modelResource.endsWith(".bbmodel");
-		final boolean isObj = modelResource.endsWith(".obj");
+		final boolean isObjOrMqo = ModelResourceLoader.isObjOrMqo(modelResource);
 		final Identifier textureId = CustomResourceTools.formatIdentifierWithDefault(textureResource, "png");
-		final ObjectObjectImmutablePair<OptimizedModelWrapper, DynamicVehicleModel> models;
+		ObjectObjectImmutablePair<OptimizedModelWrapper, DynamicVehicleModel> models;
 
 		if (isBlockbench) {
 			final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroups = new Object2ObjectOpenHashMap<>();
@@ -36,24 +36,24 @@ public interface StoredModelResourceBase {
 			);
 			tempDynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroups, new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>());
 			models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromMaterialGroups(materialGroups.get(PartCondition.NORMAL)), tempDynamicVehicleModel);
-		} else if (isObj) {
-			final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>> objModels = new Object2ObjectOpenHashMap<>();
-			final Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> rawModels = new Object2ObjectAVLTreeMap<>(OptimizedModel.ObjModel.loadModel(
-					resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "obj")),
-					mtlString -> resourceProvider.get(CustomResourceTools.getResourceFromSamePath(modelResource, mtlString, "mtl")),
-					textureString -> StringUtils.isEmpty(textureString) ? OptimizedModelWrapper.WHITE_TEXTURE : StringUtils.equals(textureString, "default.png") ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
-					null, true, flipTextureV
-			));
-			transform(rawModels.values());
-			final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(
-					rawModels,
-					textureId,
-					new ModelProperties(modelYOffset),
-					new PositionDefinitions(),
-					""
-			);
-			dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), objModels);
-			models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromObjModels(objModels.get(PartCondition.NORMAL)), dynamicVehicleModel);
+		} else if (isObjOrMqo) {
+			try {
+				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>> objModels = new Object2ObjectOpenHashMap<>();
+				final Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> rawModels = ModelResourceLoader.loadObjOrMqo(modelResource, textureId, flipTextureV, resourceProvider);
+				transform(rawModels.values());
+				final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(
+						rawModels,
+						textureId,
+						new ModelProperties(modelYOffset),
+						new PositionDefinitions(),
+						""
+				);
+				dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), objModels);
+				models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromObjModels(objModels.get(PartCondition.NORMAL)), dynamicVehicleModel);
+			} catch (Exception e) {
+				Init.LOGGER.error("[{}] Invalid OBJ/MQO model!", modelResource, e);
+				models = new ObjectObjectImmutablePair<>(null, null);
+			}
 		} else {
 			models = new ObjectObjectImmutablePair<>(null, null);
 		}

--- a/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
@@ -21,7 +21,7 @@ public interface StoredModelResourceBase {
 		CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
 
 		final boolean isBlockbench = modelResource.endsWith(".bbmodel");
-		final boolean isObjOrMqo = ModelResourceLoader.isObjOrMqo(modelResource);
+		final boolean isSupportedModelResource = ModelResourceLoader.isSupportedModelResource(modelResource);
 		final Identifier textureId = CustomResourceTools.formatIdentifierWithDefault(textureResource, "png");
 		ObjectObjectImmutablePair<OptimizedModelWrapper, DynamicVehicleModel> models;
 
@@ -36,10 +36,10 @@ public interface StoredModelResourceBase {
 			);
 			tempDynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroups, new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>());
 			models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromMaterialGroups(materialGroups.get(PartCondition.NORMAL)), tempDynamicVehicleModel);
-		} else if (isObjOrMqo) {
+		} else if (isSupportedModelResource) {
 			try {
 				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>> objModels = new Object2ObjectOpenHashMap<>();
-				final Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> rawModels = ModelResourceLoader.loadObjOrMqo(modelResource, textureId, flipTextureV, resourceProvider);
+				final Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> rawModels = ModelResourceLoader.loadModel(modelResource, textureId, flipTextureV, resourceProvider);
 				transform(rawModels.values());
 				final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(
 						rawModels,
@@ -51,7 +51,7 @@ public interface StoredModelResourceBase {
 				dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), objModels);
 				models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromObjModels(objModels.get(PartCondition.NORMAL)), dynamicVehicleModel);
 			} catch (Exception e) {
-				Init.LOGGER.error("[{}] Invalid OBJ/MQO model!", modelResource, e);
+				Init.LOGGER.error("[{}] Invalid model!", modelResource, e);
 				models = new ObjectObjectImmutablePair<>(null, null);
 			}
 		} else {

--- a/fabric/src/main/java/org/mtr/mod/resource/VehicleModel.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/VehicleModel.java
@@ -125,14 +125,14 @@ public final class VehicleModel extends VehicleModelSchema {
 			);
 			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
 			return dynamicVehicleModel;
-		} else if (ModelResourceLoader.isObjOrMqo(modelResource)) {
+		} else if (ModelResourceLoader.isSupportedModelResource(modelResource)) {
 			try {
 				CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
-				final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(ModelResourceLoader.loadObjOrMqo(modelResource, textureId, flipTextureV, resourceProvider), textureId, modelProperties, positionDefinitions, id);
+				final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(ModelResourceLoader.loadModel(modelResource, textureId, flipTextureV, resourceProvider), textureId, modelProperties, positionDefinitions, id);
 				CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
 				return dynamicVehicleModel;
 			} catch (Exception e) {
-				Init.LOGGER.error("[{}] Invalid OBJ/MQO model!", modelResource, e);
+				Init.LOGGER.error("[{}] Invalid model!", modelResource, e);
 				CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
 			}
 		} else {

--- a/fabric/src/main/java/org/mtr/mod/resource/VehicleModel.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/VehicleModel.java
@@ -1,15 +1,12 @@
 package org.mtr.mod.resource;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mtr.core.serializer.JsonReader;
 import org.mtr.core.serializer.ReaderBase;
 import org.mtr.core.tool.Utilities;
 import org.mtr.libraries.com.google.gson.JsonObject;
-import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import org.mtr.mapping.holder.Identifier;
-import org.mtr.mapping.mapper.OptimizedModel;
 import org.mtr.mod.Init;
 import org.mtr.mod.client.CustomResourceLoader;
 import org.mtr.mod.generated.resource.VehicleModelSchema;
@@ -128,28 +125,29 @@ public final class VehicleModel extends VehicleModelSchema {
 			);
 			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
 			return dynamicVehicleModel;
-		} else if (modelResource.endsWith(".obj")) {
-			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
-			final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(new Object2ObjectAVLTreeMap<>(OptimizedModel.ObjModel.loadModel(
-					resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "obj")),
-					mtlString -> resourceProvider.get(CustomResourceTools.getResourceFromSamePath(modelResource, mtlString, "mtl")),
-					textureString -> StringUtils.isEmpty(textureString) ? OptimizedModelWrapper.WHITE_TEXTURE : StringUtils.equals(textureString, "default.png") ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
-					null, true, flipTextureV
-			)), textureId, modelProperties, positionDefinitions, id);
-			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
-			return dynamicVehicleModel;
+		} else if (ModelResourceLoader.isObjOrMqo(modelResource)) {
+			try {
+				CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
+				final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(ModelResourceLoader.loadObjOrMqo(modelResource, textureId, flipTextureV, resourceProvider), textureId, modelProperties, positionDefinitions, id);
+				CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
+				return dynamicVehicleModel;
+			} catch (Exception e) {
+				Init.LOGGER.error("[{}] Invalid OBJ/MQO model!", modelResource, e);
+				CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
+			}
 		} else {
 			Init.LOGGER.error("[{}] Invalid model!", textureId.data.toString());
-			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
-			final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(
-					new BlockbenchModel(new JsonReader(new JsonObject())),
-					textureId,
-					modelProperties,
-					positionDefinitions,
-					id
-			);
-			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
-			return dynamicVehicleModel;
 		}
+
+		CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
+		final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(
+				new BlockbenchModel(new JsonReader(new JsonObject())),
+				textureId,
+				modelProperties,
+				positionDefinitions,
+				id
+		);
+		CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
+		return dynamicVehicleModel;
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/servlet/AbstractResourcePackCreatorServlet.java
+++ b/fabric/src/main/java/org/mtr/mod/servlet/AbstractResourcePackCreatorServlet.java
@@ -1,5 +1,6 @@
 package org.mtr.mod.servlet;
 
+import org.apache.commons.io.IOUtils;
 import org.mtr.core.serializer.JsonReader;
 import org.mtr.core.servlet.HttpResponseStatus;
 import org.mtr.core.servlet.ServletBase;
@@ -19,16 +20,19 @@ import org.mtr.mod.resource.BlockbenchModel;
 import org.mtr.mod.resource.BlockbenchModelValidator;
 import org.mtr.mod.resource.ModelResourceLoader;
 import org.mtr.mod.resource.ModelWrapper;
+import org.mtr.mod.resource.ResourceProvider;
 import org.mtr.mod.resource.ResourceWrapper;
 import org.mtr.mod.screen.ReloadCustomResourcesScreen;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 public abstract class AbstractResourcePackCreatorServlet extends HttpServlet {
 
 	protected static final Object2ObjectAVLTreeMap<String, String> MODELS = new Object2ObjectAVLTreeMap<>();
+	protected static final Object2ObjectAVLTreeMap<String, byte[]> MODEL_BYTES = new Object2ObjectAVLTreeMap<>();
 	protected static final Object2ObjectAVLTreeMap<String, byte[]> TEXTURES = new Object2ObjectAVLTreeMap<>();
 
 	@Nullable
@@ -88,6 +92,9 @@ public abstract class AbstractResourcePackCreatorServlet extends HttpServlet {
 			} else if (name.endsWith(".obj") || name.endsWith(".mqo")) {
 				resourceWrapper.addModelResource(new ModelWrapper(name, ModelResourceLoader.getModelParts(name, content)));
 				MODELS.put(name, content);
+			} else if (name.endsWith(".mqoz")) {
+				resourceWrapper.addModelResource(new ModelWrapper(name, ModelResourceLoader.getModelParts(name, bytes)));
+				MODEL_BYTES.put(name, bytes);
 			} else if (name.endsWith(".mtl")) {
 				MODELS.put(name, content);
 			}
@@ -111,11 +118,36 @@ public abstract class AbstractResourcePackCreatorServlet extends HttpServlet {
 		CustomResourceLoader.clearCustomVehicles(refreshVehicleId);
 		new ResourceWrapper(new JsonReader(vehiclesFlattened), new ObjectArrayList<>(), new ObjectArrayList<>()).iterateVehicles(vehicleResourceWrapper -> {
 			if (refreshVehicleId.isEmpty() || vehicleResourceWrapper.getId().equals(refreshVehicleId)) {
-				CustomResourceLoader.registerVehicle(vehicleResourceWrapper.toVehicleResource(identifier -> {
-					final String modelString = ResourcePackCreatorUploadServlet.getModel(identifier.data.toString());
-					return modelString == null ? ResourceManagerHelper.readResource(identifier) : modelString;
-				}, null, null));
+				CustomResourceLoader.registerVehicle(vehicleResourceWrapper.toVehicleResource(getResourceProvider(), null, null));
 			}
 		});
+	}
+
+	protected static ResourceProvider getResourceProvider() {
+		return new ResourceProvider() {
+			@Override
+			public String get(Identifier identifier) {
+				final String modelString = ResourcePackCreatorUploadServlet.getModel(identifier.data.toString());
+				return modelString == null ? ResourceManagerHelper.readResource(identifier) : modelString;
+			}
+
+			@Override
+			public byte[] getBytes(Identifier identifier) {
+				final byte[] modelBytes = ResourcePackCreatorUploadServlet.getModelBytes(identifier.data.toString());
+				if (modelBytes != null) {
+					return modelBytes;
+				}
+
+				final byte[][] bytes = new byte[1][];
+				ResourceManagerHelper.readResource(identifier, inputStream -> {
+					try {
+						bytes[0] = IOUtils.toByteArray(inputStream);
+					} catch (Exception e) {
+						Init.LOGGER.error("", e);
+					}
+				});
+				return bytes[0] == null ? get(identifier).getBytes(StandardCharsets.UTF_8) : bytes[0];
+			}
+		};
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/servlet/AbstractResourcePackCreatorServlet.java
+++ b/fabric/src/main/java/org/mtr/mod/servlet/AbstractResourcePackCreatorServlet.java
@@ -12,12 +12,12 @@ import org.mtr.libraries.javax.servlet.http.HttpServlet;
 import org.mtr.libraries.javax.servlet.http.HttpServletRequest;
 import org.mtr.libraries.javax.servlet.http.HttpServletResponse;
 import org.mtr.mapping.holder.*;
-import org.mtr.mapping.mapper.OptimizedModel;
 import org.mtr.mapping.mapper.ResourceManagerHelper;
 import org.mtr.mod.Init;
 import org.mtr.mod.client.CustomResourceLoader;
 import org.mtr.mod.resource.BlockbenchModel;
 import org.mtr.mod.resource.BlockbenchModelValidator;
+import org.mtr.mod.resource.ModelResourceLoader;
 import org.mtr.mod.resource.ModelWrapper;
 import org.mtr.mod.resource.ResourceWrapper;
 import org.mtr.mod.screen.ReloadCustomResourcesScreen;
@@ -85,8 +85,8 @@ public abstract class AbstractResourcePackCreatorServlet extends HttpServlet {
 				new BlockbenchModel(new JsonReader(modelObject)).getOutlines().forEach(blockbenchOutline -> modelParts.add(blockbenchOutline.getName()));
 				resourceWrapper.addModelResource(new ModelWrapper(name, modelParts));
 				MODELS.put(name, modelObject.toString());
-			} else if (name.endsWith(".obj")) {
-				resourceWrapper.addModelResource(new ModelWrapper(name, new ObjectArrayList<>(OptimizedModel.ObjModel.loadModel(content, mtlString -> "", textureString -> new Identifier(""), null, true, false).keySet())));
+			} else if (name.endsWith(".obj") || name.endsWith(".mqo")) {
+				resourceWrapper.addModelResource(new ModelWrapper(name, ModelResourceLoader.getModelParts(name, content)));
 				MODELS.put(name, content);
 			} else if (name.endsWith(".mtl")) {
 				MODELS.put(name, content);

--- a/fabric/src/main/java/org/mtr/mod/servlet/ResourcePackCreatorUploadServlet.java
+++ b/fabric/src/main/java/org/mtr/mod/servlet/ResourcePackCreatorUploadServlet.java
@@ -84,10 +84,15 @@ public final class ResourcePackCreatorUploadServlet extends AbstractResourcePack
 		return MODELS.get(name);
 	}
 
+	static byte[] getModelBytes(String name) {
+		return MODEL_BYTES.get(name);
+	}
+
 	private static void reset() {
 		final ObjectArrayList<String> texturesToDestroy = new ObjectArrayList<>(TEXTURES.keySet());
 		resourceWrapper = null;
 		MODELS.clear();
+		MODEL_BYTES.clear();
 		TEXTURES.clear();
 
 		try {
@@ -127,7 +132,7 @@ public final class ResourcePackCreatorUploadServlet extends AbstractResourcePack
 
 						if (name.equals(String.format("%s:%s.json", Init.MOD_ID, CustomResourceLoader.CUSTOM_RESOURCES_ID))) {
 							customResourcesObject = Utilities.parseJson(content);
-						} else if (name.endsWith(".png") || name.endsWith(".bbmodel") || name.endsWith(".obj") || name.endsWith(".mtl")) {
+						} else if (name.endsWith(".png") || name.endsWith(".bbmodel") || name.endsWith(".obj") || name.endsWith(".mqo") || name.endsWith(".mqoz") || name.endsWith(".mtl")) {
 							resourceUploadTasks.add(() -> uploadResource(name, bytes, content));
 						} else if (name.endsWith(".json")) {
 							jsonCache.put(name, content);
@@ -193,10 +198,7 @@ public final class ResourcePackCreatorUploadServlet extends AbstractResourcePack
 				final ObjectArrayList<VehicleResource> vehicles = new ObjectArrayList<>();
 				final Object2ObjectArrayMap<String, ModelProperties> modelPropertiesMap = new Object2ObjectArrayMap<>();
 				final Object2ObjectArrayMap<String, PositionDefinitions> positionDefinitionsMap = new Object2ObjectArrayMap<>();
-				new ResourceWrapper(new JsonReader(vehiclesFlattened), new ObjectArrayList<>(), new ObjectArrayList<>()).iterateVehicles(vehicleResourceWrapper -> vehicles.add(vehicleResourceWrapper.toVehicleResource(identifier -> {
-					final String modelString = ResourcePackCreatorUploadServlet.getModel(identifier.data.toString());
-					return modelString == null ? ResourceManagerHelper.readResource(identifier) : modelString;
-				}, modelPropertiesMap, positionDefinitionsMap)));
+				new ResourceWrapper(new JsonReader(vehiclesFlattened), new ObjectArrayList<>(), new ObjectArrayList<>()).iterateVehicles(vehicleResourceWrapper -> vehicles.add(vehicleResourceWrapper.toVehicleResource(getResourceProvider(), modelPropertiesMap, positionDefinitionsMap)));
 				final CustomResources customResources = new CustomResources(vehicles, new ObjectArrayList<>());
 				final String resourcePackFolder = String.format("%s/resourcepacks", MinecraftClient.getInstance().getRunDirectoryMapped());
 				final String filePath = String.format("%s/%s-%s.zip", resourcePackFolder, name, DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").format(LocalDateTime.now()));
@@ -209,6 +211,7 @@ public final class ResourcePackCreatorUploadServlet extends AbstractResourcePack
 					writeToZipOutputStream(modelPropertiesMap, zipOutputStream, modelProperties -> IOUtils.write(Utilities.getJsonObjectFromData(modelProperties).toString(), zipOutputStream, StandardCharsets.UTF_8));
 					writeToZipOutputStream(positionDefinitionsMap, zipOutputStream, positionDefinitions -> IOUtils.write(Utilities.getJsonObjectFromData(positionDefinitions).toString(), zipOutputStream, StandardCharsets.UTF_8));
 					writeToZipOutputStream(MODELS, zipOutputStream, modelString -> IOUtils.write(modelString, zipOutputStream, StandardCharsets.UTF_8));
+					writeToZipOutputStream(MODEL_BYTES, zipOutputStream, modelBytes -> IOUtils.write(modelBytes, zipOutputStream));
 					writeToZipOutputStream(TEXTURES, zipOutputStream, textureBytes -> IOUtils.write(textureBytes, zipOutputStream));
 
 					zipOutputStream.putNextEntry(new ZipEntry(String.format("assets/%s/%s.json", Init.MOD_ID, CustomResourceLoader.CUSTOM_RESOURCES_ID)));

--- a/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
+++ b/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
@@ -8,23 +8,23 @@ public final class MqoModelConverterTest {
 
 	@Test
 	public void convertTriangleWithMaterial() {
-		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
-				Metasequoia Document
-				Format Text Ver 1.1
-				Material 1 {
-					"body" col(0.250 0.500 0.750 0.800) dif(0.600)
-				}
-				Object "body_part" {
-					vertex 3 {
-						0 0 0
-						1 0 0
-						0 1 0
-					}
-					face 1 {
-						3 V(0 1 2) M(0)
-					}
-				}
-				""");
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Material 1 {",
+				"	\"body\" col(0.250 0.500 0.750 0.800) dif(0.600)",
+				"}",
+				"Object \"body_part\" {",
+				"	vertex 3 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		0 1 0",
+				"	}",
+				"	face 1 {",
+				"		3 V(0 1 2) M(0)",
+				"	}",
+				"}"
+		));
 
 		Assertions.assertEquals("body_part", convertedModel.getModelParts().get(0));
 		Assertions.assertTrue(convertedModel.getObjContent().contains("o body_part"));
@@ -38,23 +38,23 @@ public final class MqoModelConverterTest {
 
 	@Test
 	public void convertTextureAndUv() {
-		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
-				Metasequoia Document
-				Format Text Ver 1.1
-				Material 1 {
-					"window" tex("textures/window.png")
-				}
-				Object "window" {
-					vertex 3 {
-						0 0 0
-						1 0 0
-						0 1 0
-					}
-					face 1 {
-						3 V(0 1 2) M(0) UV(0 0 1 0 0 1)
-					}
-				}
-				""");
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Material 1 {",
+				"	\"window\" tex(\"textures/window.png\")",
+				"}",
+				"Object \"window\" {",
+				"	vertex 3 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		0 1 0",
+				"	}",
+				"	face 1 {",
+				"		3 V(0 1 2) M(0) UV(0 0 1 0 0 1)",
+				"	}",
+				"}"
+		));
 
 		Assertions.assertTrue(convertedModel.getObjContent().contains("vt 0.000000 0.000000"));
 		Assertions.assertTrue(convertedModel.getObjContent().contains("vt 1.000000 0.000000"));
@@ -65,21 +65,21 @@ public final class MqoModelConverterTest {
 
 	@Test
 	public void convertQuadWithDefaultMaterial() {
-		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
-				Metasequoia Document
-				Format Text Ver 1.1
-				Object "floor" {
-					vertex 4 {
-						0 0 0
-						1 0 0
-						1 1 0
-						0 1 0
-					}
-					face 1 {
-						4 V(0 1 2 3) M(-1)
-					}
-				}
-				""");
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Object \"floor\" {",
+				"	vertex 4 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		1 1 0",
+				"		0 1 0",
+				"	}",
+				"	face 1 {",
+				"		4 V(0 1 2 3) M(-1)",
+				"	}",
+				"}"
+		));
 
 		Assertions.assertTrue(convertedModel.getObjContent().contains("usemtl mqo_default"));
 		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1//1 3//2 2//3"));
@@ -88,69 +88,73 @@ public final class MqoModelConverterTest {
 
 	@Test
 	public void convertSmoothNormals() {
-		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
-				Metasequoia Document
-				Format Text Ver 1.1
-				Object "smooth" {
-					shading 1
-					facet 180.0
-					vertex 4 {
-						0 0 0
-						1 0 0
-						0 1 0
-						0 0 1
-					}
-					face 2 {
-						3 V(0 1 2)
-						3 V(0 2 3)
-					}
-				}
-				""");
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Object \"smooth\" {",
+				"	shading 1",
+				"	facet 180.0",
+				"	vertex 4 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		0 1 0",
+				"		0 0 1",
+				"	}",
+				"	face 2 {",
+				"		3 V(0 1 2)",
+				"		3 V(0 2 3)",
+				"	}",
+				"}"
+		));
 
 		Assertions.assertTrue(convertedModel.getObjContent().contains("vn -0.707107 0.000000 -0.707107"));
 	}
 
 	@Test
 	public void ignoreUnknownObjectChildChunks() {
-		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
-				Metasequoia Document
-				Format Text Ver 1.1
-				Object "body" {
-					vertex 3 {
-						0 0 0
-						1 0 0
-						0 1 0
-					}
-					vertexattr {
-						uid {
-							1
-							2
-							3
-						}
-					}
-					face 1 {
-						3 V(0 1 2)
-					}
-				}
-				""");
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Object \"body\" {",
+				"	vertex 3 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		0 1 0",
+				"	}",
+				"	vertexattr {",
+				"		uid {",
+				"			1",
+				"			2",
+				"			3",
+				"		}",
+				"	}",
+				"	face 1 {",
+				"		3 V(0 1 2)",
+				"	}",
+				"}"
+		));
 
 		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1//1 3//2 2//3"));
 	}
 
 	@Test
 	public void rejectUnsupportedFormats() {
-		Assertions.assertThrows(IllegalArgumentException.class, () -> MqoModelConverter.convert("""
-				Metasequoia Document
-				Format Compress Ver 1.1
-				"""));
+		Assertions.assertThrows(IllegalArgumentException.class, () -> MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Compress Ver 1.1"
+		)));
 
-		Assertions.assertThrows(IllegalArgumentException.class, () -> MqoModelConverter.convert("""
-				Metasequoia Document
-				Format Text Ver 1.1
-				Object "binary" {
-					BVertex 1 {
-					}
-				}
-				"""));
+		Assertions.assertThrows(IllegalArgumentException.class, () -> MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Object \"binary\" {",
+				"	BVertex 1 {",
+				"	}",
+				"}"
+		)));
+	}
+
+	private static String mqo(String... lines) {
+		return String.join("\n", lines);
 	}
 }

--- a/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
+++ b/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
@@ -2,7 +2,13 @@ package org.mtr.test;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mtr.mod.resource.ModelResourceLoader;
 import org.mtr.mod.resource.MqoModelConverter;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 public final class MqoModelConverterTest {
 
@@ -154,7 +160,109 @@ public final class MqoModelConverterTest {
 		)));
 	}
 
+	@Test
+	public void extractMqozSingleMqo() {
+		final byte[] bytes = mqoz(
+				zipData("model.mqo", mqo(
+						"Metasequoia Document",
+						"Format Text Ver 1.1",
+						"Material 1 {",
+						"	\"body\" col(0.250 0.500 0.750 0.800) dif(0.600)",
+						"}",
+						"Object \"body_part\" {",
+						"	vertex 3 {",
+						"		0 0 0",
+						"		1 0 0",
+						"		0 1 0",
+						"	}",
+						"	face 1 {",
+						"		3 V(0 1 2) M(0)",
+						"	}",
+						"}"
+				)),
+				zipData("thumbnail.png", "ignored")
+		);
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(ModelResourceLoader.extractMqoContentFromMqoz("mtr:models/model.mqoz", bytes));
+
+		Assertions.assertEquals("body_part", ModelResourceLoader.getModelParts("mtr:models/model.mqoz", bytes).get(0));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("v 0.010000 0.000000 0.000000"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1//1 3//2 2//3"));
+		Assertions.assertTrue(convertedModel.getMtlContent().contains("Kd 0.150000 0.300000 0.450000"));
+	}
+
+	@Test
+	public void extractMqozPrefersMatchingBaseName() {
+		final byte[] bytes = mqoz(
+				zipData("a_first.mqo", mqo(
+						"Metasequoia Document",
+						"Format Text Ver 1.1",
+						"Object \"first\" {",
+						"	vertex 3 {",
+						"		0 0 0",
+						"		1 0 0",
+						"		0 1 0",
+						"	}",
+						"	face 1 {",
+						"		3 V(0 1 2)",
+						"	}",
+						"}"
+				)),
+				zipData("folder/model.mqo", mqo(
+						"Metasequoia Document",
+						"Format Text Ver 1.1",
+						"Object \"preferred\" {",
+						"	vertex 3 {",
+						"		0 0 0",
+						"		1 0 0",
+						"		0 1 0",
+						"	}",
+						"	face 1 {",
+						"		3 V(0 1 2)",
+						"	}",
+						"}"
+				))
+		);
+
+		Assertions.assertEquals("preferred", ModelResourceLoader.getModelParts("mtr:models/model.mqoz", bytes).get(0));
+	}
+
+	@Test
+	public void rejectMqozWithoutMqo() {
+		Assertions.assertThrows(IllegalArgumentException.class, () -> ModelResourceLoader.extractMqoContentFromMqoz("mtr:models/model.mqoz", mqoz(zipData("model.mqx", "ignored"))));
+	}
+
 	private static String mqo(String... lines) {
 		return String.join("\n", lines);
+	}
+
+	private static ZipData zipData(String name, String content) {
+		return new ZipData(name, content);
+	}
+
+	private static byte[] mqoz(ZipData... zipDataArray) {
+		try {
+			final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+			final ZipOutputStream zipOutputStream = new ZipOutputStream(byteArrayOutputStream);
+			for (final ZipData zipData : zipDataArray) {
+				zipOutputStream.putNextEntry(new ZipEntry(zipData.name));
+				zipOutputStream.write(zipData.content.getBytes(StandardCharsets.UTF_8));
+				zipOutputStream.closeEntry();
+			}
+			zipOutputStream.close();
+			return byteArrayOutputStream.toByteArray();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static final class ZipData {
+
+		private final String name;
+		private final String content;
+
+		private ZipData(String name, String content) {
+			this.name = name;
+			this.content = content;
+		}
 	}
 }

--- a/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
+++ b/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
@@ -1,0 +1,156 @@
+package org.mtr.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mtr.mod.resource.MqoModelConverter;
+
+public final class MqoModelConverterTest {
+
+	@Test
+	public void convertTriangleWithMaterial() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
+				Metasequoia Document
+				Format Text Ver 1.1
+				Material 1 {
+					"body" col(0.250 0.500 0.750 0.800) dif(0.600)
+				}
+				Object "body_part" {
+					vertex 3 {
+						0 0 0
+						1 0 0
+						0 1 0
+					}
+					face 1 {
+						3 V(0 1 2) M(0)
+					}
+				}
+				""");
+
+		Assertions.assertEquals("body_part", convertedModel.getModelParts().get(0));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("o body_part"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("v 0.010000 0.000000 0.000000"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("vn 0.000000 0.000000 -1.000000"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("usemtl mqo_material_0"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1//1 3//2 2//3"));
+		Assertions.assertTrue(convertedModel.getMtlContent().contains("Kd 0.150000 0.300000 0.450000"));
+		Assertions.assertTrue(convertedModel.getMtlContent().contains("d 0.800000"));
+	}
+
+	@Test
+	public void convertTextureAndUv() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
+				Metasequoia Document
+				Format Text Ver 1.1
+				Material 1 {
+					"window" tex("textures/window.png")
+				}
+				Object "window" {
+					vertex 3 {
+						0 0 0
+						1 0 0
+						0 1 0
+					}
+					face 1 {
+						3 V(0 1 2) M(0) UV(0 0 1 0 0 1)
+					}
+				}
+				""");
+
+		Assertions.assertTrue(convertedModel.getObjContent().contains("vt 0.000000 0.000000"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("vt 1.000000 0.000000"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("vt 0.000000 1.000000"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1/1/1 3/2/2 2/3/3"));
+		Assertions.assertTrue(convertedModel.getMtlContent().contains("map_Kd textures/window.png"));
+	}
+
+	@Test
+	public void convertQuadWithDefaultMaterial() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
+				Metasequoia Document
+				Format Text Ver 1.1
+				Object "floor" {
+					vertex 4 {
+						0 0 0
+						1 0 0
+						1 1 0
+						0 1 0
+					}
+					face 1 {
+						4 V(0 1 2 3) M(-1)
+					}
+				}
+				""");
+
+		Assertions.assertTrue(convertedModel.getObjContent().contains("usemtl mqo_default"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1//1 3//2 2//3"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1//4 4//5 3//6"));
+	}
+
+	@Test
+	public void convertSmoothNormals() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
+				Metasequoia Document
+				Format Text Ver 1.1
+				Object "smooth" {
+					shading 1
+					facet 180.0
+					vertex 4 {
+						0 0 0
+						1 0 0
+						0 1 0
+						0 0 1
+					}
+					face 2 {
+						3 V(0 1 2)
+						3 V(0 2 3)
+					}
+				}
+				""");
+
+		Assertions.assertTrue(convertedModel.getObjContent().contains("vn -0.707107 0.000000 -0.707107"));
+	}
+
+	@Test
+	public void ignoreUnknownObjectChildChunks() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert("""
+				Metasequoia Document
+				Format Text Ver 1.1
+				Object "body" {
+					vertex 3 {
+						0 0 0
+						1 0 0
+						0 1 0
+					}
+					vertexattr {
+						uid {
+							1
+							2
+							3
+						}
+					}
+					face 1 {
+						3 V(0 1 2)
+					}
+				}
+				""");
+
+		Assertions.assertTrue(convertedModel.getObjContent().contains("f 1//1 3//2 2//3"));
+	}
+
+	@Test
+	public void rejectUnsupportedFormats() {
+		Assertions.assertThrows(IllegalArgumentException.class, () -> MqoModelConverter.convert("""
+				Metasequoia Document
+				Format Compress Ver 1.1
+				"""));
+
+		Assertions.assertThrows(IllegalArgumentException.class, () -> MqoModelConverter.convert("""
+				Metasequoia Document
+				Format Text Ver 1.1
+				Object "binary" {
+					BVertex 1 {
+					}
+				}
+				"""));
+	}
+}

--- a/website/src/app/component/edit/edit.component.ts
+++ b/website/src/app/component/edit/edit.component.ts
@@ -82,7 +82,7 @@ export class EditComponent {
 				title: "Models",
 				addText: "Add Model",
 				deleteText: "Delete Model",
-				fileExtensions: ["bbmodel", "obj", "mqo", "mtl"],
+				fileExtensions: ["bbmodel", "obj", "mqo", "mqoz", "mtl"],
 				listCustomSupplier: () => this.dataService.models().map(modelWrapper => modelWrapper.id),
 				listMinecraftSupplier: () => this.dataService.minecraftModelResources().map(minecraftModelResource => minecraftModelResource.modelResource),
 			},

--- a/website/src/app/component/edit/edit.component.ts
+++ b/website/src/app/component/edit/edit.component.ts
@@ -82,7 +82,7 @@ export class EditComponent {
 				title: "Models",
 				addText: "Add Model",
 				deleteText: "Delete Model",
-				fileExtensions: ["bbmodel", "obj", "mtl"],
+				fileExtensions: ["bbmodel", "obj", "mqo", "mtl"],
 				listCustomSupplier: () => this.dataService.models().map(modelWrapper => modelWrapper.id),
 				listMinecraftSupplier: () => this.dataService.minecraftModelResources().map(minecraftModelResource => minecraftModelResource.modelResource),
 			},

--- a/website/src/app/component/manage-resources/manage-resources.dialog.ts
+++ b/website/src/app/component/manage-resources/manage-resources.dialog.ts
@@ -41,9 +41,10 @@ export class ManageResourcesDialog {
 		const matchingPairsObj: string[] = [];
 		const matchingPairsMtl: string[] = [];
 		fileNames.forEach(([fileName, fileExtension]) => {
-			if (fileExtension === "obj") {
+			const lowerCaseFileExtension = fileExtension.toLowerCase();
+			if (lowerCaseFileExtension === "obj") {
 				matchingPairsObj.push(fileName);
-			} else if (fileExtension === "mtl") {
+			} else if (lowerCaseFileExtension === "mtl") {
 				matchingPairsMtl.push(fileName);
 			}
 		});


### PR DESCRIPTION
.mqo is a proprietary model format of Metasequoia4, a commonly used modeling software in the RTM community.

The implementation approach is as follows: .mqo files are first converted, then the same OBJ loader is called. This ensures compatibility with existing OBJ pipelines.