### PR TITLE
Patch and fixes (4.0.x)

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/item/ItemLiftRefresher.java
+++ b/fabric/src/main/java/org/mtr/mod/item/ItemLiftRefresher.java
@@ -11,6 +11,7 @@ import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.mtr.mapping.holder.*;
 import org.mtr.mapping.mapper.DirectionHelper;
 import org.mtr.mapping.mapper.ItemExtension;
+import org.mtr.mapping.mapper.TextHelper;
 import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockLiftTrackBase;
 import org.mtr.mod.block.BlockLiftTrackFloor;
@@ -57,6 +58,10 @@ public class ItemLiftRefresher extends ItemExtension implements DirectionHelper 
 			final ObjectArrayList<LiftFloor> liftFloors = new ObjectArrayList<>();
 			liftFloors.addAll(reverseList(liftFloors1));
 			liftFloors.addAll(liftFloors2);
+			if(liftFloors.size() == 1) {
+				playerEntity.sendMessage(TranslationProvider.GUI_MTR_LIFT_MIN_FLOORS_REQUIRED.getText(), true);
+				return ActionResult.getFailMapped();
+			}
 			final boolean needsReverse = Utilities.getElement(liftFloors, -1).getPosition().getY() < Utilities.getElement(liftFloors, 0).getPosition().getY();
 			sendUpdate(ServerWorld.cast(world), needsReverse ? reverseList(liftFloors) : liftFloors);
 			Init.REGISTRY.sendPacketToClient(ServerPlayerEntity.cast(playerEntity), new PacketOpenLiftCustomizationScreen(Init.positionToBlockPos(liftFloors.get(0).getPosition())));

--- a/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
@@ -316,15 +316,14 @@ public class RenderRails implements IGui {
 
 	private static void renderWithinRenderDistance(Rail rail, RenderRailWithBlockPos callback, double interval, float offsetRadius1, float offsetRadius2) {
 		final Camera camera = MinecraftClient.getInstance().getGameRendererMapped().getCamera();
-		final Vector3i cameraBlockPos = new Vector3i(camera.getBlockPos().data);
 		final Vector3d cameraPosition = camera.getPos();
 		final int renderDistance = MinecraftClientHelper.getRenderDistance() * 16;
 
 		rail.railMath.render((x1, z1, x2, z2, x3, z3, x4, z4, y1, y2) -> {
 			final BlockPos blockPos = Init.newBlockPos(x1, y1 + LIGHT_REFERENCE_OFFSET, z1);
-			final int distance = blockPos.getManhattanDistance(cameraBlockPos);
-			if (distance <= renderDistance) {
-				if (distance < 32) {
+			final double distanceToCamera = new Vector3d(x1, 0, z1).distanceTo(new Vector3d(cameraPosition.getXMapped(), 0, cameraPosition.getZMapped())); // Minecraft does not have vertical render distance, no need to compare the Y-axis.
+			if (distanceToCamera <= renderDistance) {
+				if (distanceToCamera < 32) {
 					callback.renderRail(blockPos, x1, z1, x2, z2, x3, z3, x4, z4, y1, y2);
 				} else {
 					final Vector3d rotatedVector = new Vector3d(x1, y1, z1).subtract(cameraPosition).rotateY((float) Math.toRadians(camera.getYaw())).rotateX((float) Math.toRadians(camera.getPitch()));

--- a/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
@@ -204,7 +204,7 @@ public class RenderRails implements IGui {
 		}
 
 		if (!OptimizedRenderer.renderingShadows()) {
-			MainRenderer.WORKER_THREAD.scheduleRails(occlusionCullingInstance -> {
+			MainRenderer.WORKER_THREAD.scheduleMTRRails(occlusionCullingInstance -> {
 				final ObjectArrayList<Runnable> tasks = new ObjectArrayList<>();
 				cullingTasks.forEach(occlusionCullingInstanceRunnableFunction -> tasks.add(occlusionCullingInstanceRunnableFunction.apply(occlusionCullingInstance)));
 				minecraftClient.execute(() -> tasks.forEach(Runnable::run));

--- a/fabric/src/main/java/org/mtr/mod/render/WorkerThread.java
+++ b/fabric/src/main/java/org/mtr/mod/render/WorkerThread.java
@@ -24,6 +24,7 @@ public final class WorkerThread extends CustomThread {
 	private OcclusionCullingInstance occlusionCullingInstance;
 	private final ObjectArrayList<Consumer<OcclusionCullingInstance>> occlusionQueueVehicle = new ObjectArrayList<>();
 	private final ObjectArrayList<Consumer<OcclusionCullingInstance>> occlusionQueueLift = new ObjectArrayList<>();
+	private final ObjectArrayList<Consumer<OcclusionCullingInstance>> occlusionQueueMisc = new ObjectArrayList<>();
 	private final ObjectArrayList<Consumer<OcclusionCullingInstance>> occlusionQueueRail = new ObjectArrayList<>();
 	private final ObjectArrayList<Runnable> dynamicTextureQueue = new ObjectArrayList<>();
 
@@ -33,12 +34,13 @@ public final class WorkerThread extends CustomThread {
 			Thread.sleep(10); // Give the CPU a little break
 		} catch (InterruptedException e) {}
 
-		if (!occlusionQueueVehicle.isEmpty() || !occlusionQueueLift.isEmpty() || !occlusionQueueRail.isEmpty()) {
+		if (!occlusionQueueVehicle.isEmpty() || !occlusionQueueLift.isEmpty() || !occlusionQueueMisc.isEmpty() || !occlusionQueueRail.isEmpty()) {
 			updateInstance();
 			occlusionCullingInstance.resetCache();
 			run(occlusionQueueVehicle, task -> task.accept(occlusionCullingInstance));
 			run(occlusionQueueLift, task -> task.accept(occlusionCullingInstance));
 			run(occlusionQueueRail, task -> task.accept(occlusionCullingInstance));
+			run(occlusionQueueMisc, task -> task.accept(occlusionCullingInstance));
 		}
 
 		run(dynamicTextureQueue, Runnable::run);
@@ -61,7 +63,14 @@ public final class WorkerThread extends CustomThread {
 		}
 	}
 
+	@Deprecated
 	public void scheduleRails(Consumer<OcclusionCullingInstance> consumer) {
+		if (occlusionQueueMisc.size() < MAX_QUEUE_SIZE) {
+			occlusionQueueMisc.add(consumer);
+		}
+	}
+
+	void scheduleMTRRails(Consumer<OcclusionCullingInstance> consumer) {
 		if (occlusionQueueRail.size() < MAX_QUEUE_SIZE) {
 			occlusionQueueRail.add(consumer);
 		}

--- a/fabric/src/main/java/org/mtr/mod/resource/SignResource.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/SignResource.java
@@ -12,17 +12,21 @@ public final class SignResource extends SignResourceSchema {
 	// Default signs (the ones bundled with Minecraft Transit Railway) have IDs starting with "!"
 	public final boolean isDefault;
 	public final String signId;
+	private final Identifier parsedTextureId;
+	private final int parsedBackgroundColor;
 
 	public SignResource(ReaderBase readerBase) {
 		super(readerBase);
 		updateData(readerBase);
-		hasCustomText = !customText.isEmpty();
-		isDefault = id.startsWith("!");
-		signId = isDefault ? id.substring(1) : id;
+		this.hasCustomText = !customText.isEmpty();
+		this.isDefault = id.startsWith("!");
+		this.signId = isDefault ? id.substring(1) : id;
+		this.parsedTextureId = CustomResourceTools.formatIdentifierWithDefault(textureResource, "png");
+		this.parsedBackgroundColor = CustomResourceTools.colorStringToInt(backgroundColor);
 	}
 
 	public Identifier getTexture() {
-		return CustomResourceTools.formatIdentifierWithDefault(textureResource, "png");
+		return this.parsedTextureId;
 	}
 
 	public boolean getFlipTexture() {
@@ -42,6 +46,6 @@ public final class SignResource extends SignResourceSchema {
 	}
 
 	public int getBackgroundColor() {
-		return CustomResourceTools.colorStringToInt(backgroundColor);
+		return parsedBackgroundColor;
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/screen/EditDepotScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/EditDepotScreen.java
@@ -6,6 +6,7 @@ import org.mtr.core.operation.DepotOperationByIds;
 import org.mtr.core.operation.UpdateDataRequest;
 import org.mtr.core.tool.Utilities;
 import org.mtr.libraries.it.unimi.dsi.fastutil.longs.Long2LongAVLTreeMap;
+import org.mtr.libraries.it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectImmutableList;
 import org.mtr.mapping.holder.ClickableWidget;
@@ -334,7 +335,7 @@ public class EditDepotScreen extends EditNameColorScreenBase<Depot> {
 
 			if (departureSplit.length > 1) {
 				final String[] intervalSplit = departureSplit[1].split("\\*");
-				multiple = Integer.parseInt(intervalSplit[0]) + 1;
+				multiple = Math.min(MILLIS_PER_DAY / MILLIS_PER_SECOND, Integer.parseInt(intervalSplit[0]) + 1);
 				final String[] timeSplit2 = intervalSplit[1].split(":");
 				interval = (Integer.parseInt(timeSplit2[0]) * 3600 + Integer.parseInt(timeSplit2[1]) * 60 + Integer.parseInt(timeSplit2[2])) * 1000;
 			} else {
@@ -343,15 +344,15 @@ public class EditDepotScreen extends EditNameColorScreenBase<Depot> {
 			}
 
 			if (addToList || removeFromList) {
-				for (int i = 0; i < multiple; i++) {
-					final int rawDeparture = (departure + i * interval) % MILLIS_PER_DAY;
-					if (addToList) {
-						if (!data.getRealTimeDepartures().contains(rawDeparture)) {
-							data.getRealTimeDepartures().add(rawDeparture);
-						}
-					} else {
-						data.getRealTimeDepartures().rem(rawDeparture);
-					}
+				LongLinkedOpenHashSet newDepartures = new LongLinkedOpenHashSet();
+				for (long i = 0; i < multiple; i++) {
+					final long rawDeparture = (departure + i * interval) % MILLIS_PER_DAY;
+					newDepartures.add(rawDeparture);
+				}
+				if(addToList) {
+					data.getRealTimeDepartures().addAll(newDepartures);
+				} else {
+					data.getRealTimeDepartures().removeAll(newDepartures);
 				}
 				updateList();
 			}

--- a/fabric/src/main/resources/assets/mtr/lang/en_us.json
+++ b/fabric/src/main/resources/assets/mtr/lang/en_us.json
@@ -253,6 +253,7 @@
 	"gui.mtr.lift_floor_description": "Description",
 	"gui.mtr.lift_floor_number": "Floor Number",
 	"gui.mtr.lift_is_double_sided": "Double-sided",
+	"gui.mtr.lift_min_floors_required": "At least 2 floors are required.",
 	"gui.mtr.lift_should_ding": "Play \"Ding\" Sound",
 	"gui.mtr.lift_style": "Style: %s",
 	"gui.mtr.lift_track_required": "Lift / Elevator Tracks Required",


### PR DESCRIPTION
- Parse railway sign colors & texture ID on creation instead of every frame to slightly improve in-game performance
- Improve rail render distance check (to appear more seamless in the game)
  - Y difference is no longer accounted in the distance, since Minecraft renders all the way in the Y axis. This fixes an effect where rail segments disappears as you go higher
  - Changed to compare with Vector3d instead of BlockPos, which should be more accurate
- No longer allow spawning lift with 1 floors. (#1383)
- Use HashSet and limit no. of departures for adding, in order to cater for large amounts of departure (#1154) (Yes you can now add departure for every second within a day, although I would not necessarily recommend doing so)